### PR TITLE
Fix Android crashing on reload

### DIFF
--- a/packages/vscode-extension/src/devices/AndroidEmulatorDevice.ts
+++ b/packages/vscode-extension/src/devices/AndroidEmulatorDevice.ts
@@ -84,7 +84,7 @@ export class AndroidEmulatorDevice extends DeviceBase {
     });
     await subprocess;
     if (runningPid) {
-      await exec("kill", ["-9", `${runningPid}`]);
+      process.kill(Number(runningPid), 9);
     }
   }
 

--- a/packages/vscode-extension/src/devices/AndroidEmulatorDevice.ts
+++ b/packages/vscode-extension/src/devices/AndroidEmulatorDevice.ts
@@ -72,7 +72,7 @@ export class AndroidEmulatorDevice extends DeviceBase {
     ]);
   }
 
-  private async checkIfOldDeviceIsRunning() {
+  private async ensureOldEmulatorProcessExited() {
     return new Promise<void>((resolve, reject) => {
       let runningPid: string | undefined;
       const subprocess = exec("ps", ["-A"]);
@@ -95,7 +95,7 @@ export class AndroidEmulatorDevice extends DeviceBase {
 
   async bootDevice() {
     // this prevents booting device with the same AVD twice
-    await this.checkIfOldDeviceIsRunning();
+    await this.ensureOldEmulatorProcessExited();
 
     const avdDirectory = getOrCreateAvdDirectory();
     const subprocess = exec(

--- a/packages/vscode-extension/src/devices/AndroidEmulatorDevice.ts
+++ b/packages/vscode-extension/src/devices/AndroidEmulatorDevice.ts
@@ -17,7 +17,7 @@ import { EXPO_GO_PACKAGE_NAME, fetchExpoLaunchDeeplink } from "../builders/expoG
 
 export const EMULATOR_BINARY = path.join(ANDROID_HOME, "emulator", "emulator");
 const ADB_PATH = path.join(ANDROID_HOME, "platform-tools", "adb");
-const DISPOSE_TIMEOUT = 3000;
+const DISPOSE_TIMEOUT = 9000;
 
 interface EmulatorProcessInfo {
   pid: number;

--- a/packages/vscode-extension/src/devices/AndroidEmulatorDevice.ts
+++ b/packages/vscode-extension/src/devices/AndroidEmulatorDevice.ts
@@ -75,9 +75,9 @@ export class AndroidEmulatorDevice extends DeviceBase {
   private async checkIfOldDeviceIsRunning() {
     return new Promise<void>((resolve, reject) => {
       let runningPid: string | undefined;
-      const subprocess = exec("ps", ["-A"], { env: { ...process.env } });
+      const subprocess = exec("ps", ["-A"]);
+      const regexpPattern = new RegExp(`(\\d+)\\s.*qemu.*-avd ${this.avdId}`);
       lineReader(subprocess).onLineRead(async (line) => {
-        const regexpPattern = new RegExp(`(\\d+)\\s.*${this.avdId}`);
         const regExpResult = regexpPattern.exec(line);
         if (regExpResult) {
           runningPid = regExpResult[1];


### PR DESCRIPTION
This PR solves an issue, with android reloads, that was causing new emulator  device to crash, because the old one was still active. 

Solution: 
check if the process with the same avd is running before booting the device.  

Before: 

https://github.com/software-mansion/react-native-ide/assets/159789821/3b9a5111-97ce-4b02-b8b0-51125f83bc52

After: 


https://github.com/software-mansion/react-native-ide/assets/159789821/427ae727-e5aa-44ef-bf30-0bb2e9fbbdc5

