### PR TITLE
docs: enable anonymous analytics

### DIFF
--- a/packages/docs/src/theme/Navbar/index.js
+++ b/packages/docs/src/theme/Navbar/index.js
@@ -1,17 +1,21 @@
 import useBaseUrl from "@docusaurus/useBaseUrl";
 import React from "react";
 import { Navbar } from "@swmansion/t-rex-ui";
+import { Analytics } from "@vercel/analytics/react";
 
 export default function NavbarWrapper(props) {
   const heroImages = {
     logo: useBaseUrl("/img/logo.svg"),
   };
   return (
-    <Navbar
-      isAlgoliaActive={false}
-      isThemeSwitcherShown={false}
-      heroImages={heroImages}
-      {...props}
-    />
+    <>
+      <Navbar
+        isAlgoliaActive={false}
+        isThemeSwitcherShown={false}
+        heroImages={heroImages}
+        {...props}
+      />
+      <Analytics />
+    </>
   );
 }


### PR DESCRIPTION
This PR enables cookieless, anonymous analytics to our website provided by `@vercel/analytics`.