### PR TITLE
Fix clickability of wrapped items in button-group-top

### DIFF
--- a/packages/vscode-extension/src/webview/views/PreviewView.css
+++ b/packages/vscode-extension/src/webview/views/PreviewView.css
@@ -7,10 +7,13 @@
 
   margin: 10px;
   gap: 4px;
+  position: relative;
 }
 
 .button-group-top {
   margin-bottom: 8px;
+  position: relative;
+  z-index: 1;
 }
 
 .feedback-button {


### PR DESCRIPTION
The `button-group-top` div contains various buttons, dropdowns, and other interactive elements. When the width of the container becomes small, these items wrap to the next line. However, the wrapped items were not clickable, causing usability issues. This PR addresses the clickability problem of the wrapped items in the `button-group-top `div.