### PR TITLE
Fix AVD config using invalid CPU archs

### DIFF
--- a/packages/vscode-extension/src/builders/buildAndroid.ts
+++ b/packages/vscode-extension/src/builders/buildAndroid.ts
@@ -1,4 +1,4 @@
-import { getCpuArchitecture } from "../utilities/common";
+import { getNativeABI } from "../utilities/common";
 import { ANDROID_HOME, JAVA_HOME } from "../utilities/android";
 import { Logger } from "../Logger";
 import { exec, lineReader } from "../utilities/subprocess";
@@ -75,14 +75,13 @@ export async function buildAndroid(
     return { apkPath, packageName: EXPO_GO_PACKAGE_NAME };
   }
   const androidSourceDir = getAndroidSourceDir(appRootFolder);
-  const cpuArchitecture = getCpuArchitecture();
   const buildOptions = getLaunchConfiguration();
   const productFlavor = buildOptions.android?.productFlavor || "";
   const buildType = buildOptions.android?.buildType || "debug";
   const gradleArgs = [
     "-x",
     "lint",
-    `-PreactNativeArchitectures=${cpuArchitecture}`,
+    `-PreactNativeArchitectures=${getNativeABI()}`,
     ...(forceCleanBuild ? ["clean"] : []),
     makeBuildTaskName(productFlavor, buildType),
     "--init-script", // buildProgressEvaluation init script is used log build task count for build progress logging

--- a/packages/vscode-extension/src/utilities/common.ts
+++ b/packages/vscode-extension/src/utilities/common.ts
@@ -8,11 +8,6 @@ import { ReadableStream } from "stream/web";
 import { workspace } from "vscode";
 import { Logger } from "../Logger";
 
-export enum CPU_ARCHITECTURE {
-  ARM64 = "arm64-v8a",
-  X64 = "x86_64",
-}
-
 export const ANDROID_FAIL_ERROR_MESSAGE = "Android failed.";
 export const IOS_FAIL_ERROR_MESSAGE = "IOS failed.";
 
@@ -33,14 +28,20 @@ export async function findSingleFileInWorkspace(
   return undefined;
 }
 
-export function getCpuArchitecture() {
-  const arch = os.arch();
-  switch (arch) {
+export enum ABI {
+  ARMV8 = "arm64-v8a",
+  X86 = "x86",
+  X86_64 = "x86_64",
+}
+
+export function getNativeABI() {
+  switch (process.arch) {
     case "x64":
+      return ABI.X86_64;
     case "ia32":
-      return CPU_ARCHITECTURE.X64;
+      return ABI.X86;
     default:
-      return CPU_ARCHITECTURE.ARM64;
+      return ABI.ARMV8;
   }
 }
 


### PR DESCRIPTION
We previously used `os.arch()` which returns things like `x64` or `ia32`. QEMU understands only `x86, x86_64, arm, arm64` as arch values ([Android config.ini reference](https://learn.microsoft.com/en-us/dotnet/maui/android/emulator/device-properties?view=net-maui-8.0)).

- Replaced `os.arch()` with typed `process.arch` (doing the same).
- Mapped NodeJS arch to QEMU arch.
- Fixed RN gradle arch and ABI to handle x86 as native instead of using x86_64 there.

Fixes #302.
