### PR TITLE
fix: closing modal through ide url panel

### DIFF
--- a/packages/vscode-extension/lib/expo_router_plugin.js
+++ b/packages/vscode-extension/lib/expo_router_plugin.js
@@ -35,7 +35,8 @@ function useRouterPluginMainHook({ onNavigationChange }) {
       };
     },
     requestNavigationChange: ({ pathname, params }) => {
-      router.push(pathname, params);
+      router.navigate(pathname);
+      router.setParams(params);
     },
   };
 }

--- a/packages/vscode-extension/lib/expo_router_v2_plugin.js
+++ b/packages/vscode-extension/lib/expo_router_v2_plugin.js
@@ -35,7 +35,8 @@ function useRouterPluginMainHook({ onNavigationChange }) {
       };
     },
     requestNavigationChange: ({ pathname, params }) => {
-      router.push(pathname, params);
+      router.navigate(pathname);
+      router.setParams(params);
     },
   };
 }


### PR DESCRIPTION
# The problem: 
Currently, navigating to another page is impossible if a modal is opened. The root cause of the problem is using `router.push` that does not dismiss modals. You can read more about it.
https://github.com/expo/expo/issues/26922#issuecomment-1996862878 .
However approaches that they proposed aren't good because they introduce other bugs such as unnecessarily closing modals, because of this - thanks to @kmagiera catch  (https://github.com/software-mansion/react-native-ide/pull/204#discussion_r1594708930) I eventually bet on `navigate` combined with `setParams`. This approach works smoothly without introducing additional problems.
 
# Before:
https://github.com/software-mansion/react-native-ide/assets/77052270/5b26f4cb-24cf-4c13-a57d-f33f9a20d680

By replacing the current implementation with `navigate` and `setParams ` we can eliminate the problem.

# After:
https://github.com/software-mansion/react-native-ide/assets/77052270/ff425ade-8f77-4144-bf42-18368870ee86






