### PR TITLE
Ignore vendor directory when looking for XCode files

### DIFF
--- a/packages/vscode-extension/src/builders/buildIOS.ts
+++ b/packages/vscode-extension/src/builders/buildIOS.ts
@@ -47,7 +47,7 @@ export async function findXcodeProject(appRootFolder: string) {
   const iosSourceDir = getIosSourceDir(appRootFolder);
   const xcworkspaceFiles = await workspace.findFiles(
     new RelativePattern(iosSourceDir, "**/*.xcworkspace/*"),
-    "**/{node_modules,build,Pods,*.xcodeproj}/**",
+    "**/{node_modules,build,Pods,vendor,*.xcodeproj}/**",
     2
   );
 
@@ -58,7 +58,7 @@ export async function findXcodeProject(appRootFolder: string) {
 
   const xcodeprojFiles = await workspace.findFiles(
     new RelativePattern(iosSourceDir, "**/*.xcodeproj/*"),
-    "**/{node_modules,build,Pods}/**",
+    "**/{node_modules,build,Pods,vendor}/**",
     2
   );
 


### PR DESCRIPTION
Seems like bundler stores some gems in there we want to ignore.

Tested building and running apps on bare app, expo go, and expo dev client.

Fixes #293.