### PR TITLE
Use import syntax in expo-router plugin to fix React Compiler

### DIFF
--- a/packages/vscode-extension/lib/expo_router_plugin.js
+++ b/packages/vscode-extension/lib/expo_router_plugin.js
@@ -1,7 +1,6 @@
-const { useSyncExternalStore } = require("react");
-const { useEffect } = require("react");
-const { useRouter } = require("expo-router");
-const { store } = require("expo-router/build/global-state/router-store");
+import { useSyncExternalStore, useEffect } from "react";
+import { useRouter } from "expo-router";
+import { store } from "expo-router/build/global-state/router-store.js";
 
 function computeRouteIdentifier(pathname, params) {
   return pathname + JSON.stringify(params);

--- a/packages/vscode-extension/lib/expo_router_v2_plugin.js
+++ b/packages/vscode-extension/lib/expo_router_v2_plugin.js
@@ -1,7 +1,6 @@
-const { useSyncExternalStore } = require("react");
-const { useEffect } = require("react");
-const { useRouter } = require("expo-router");
-const { store } = require("expo-router/src/global-state/router-store");
+import { useSyncExternalStore, useEffect } from "react";
+import { useRouter } from "expo-router";
+import { store } from "expo-router/src/global-state/router-store";
 
 function computeRouteIdentifier(pathname, params) {
   return pathname + JSON.stringify(params);


### PR DESCRIPTION
This PR changes require to import syntax in expo-router plugin in order to address an issue with React Compiler.

The problem with compiler was because of some weird interference of babel plugins responsible for code transforms. The compiler plugin adds import statement to file it processes in order to import its runtime. However, since there were no other imports initially in the expo-router file, that new import statement would never be processed and it'd be kept in the file causing JS error that import statements should be on top of the file (plugin file would be somewhere in the middle of the bundle, so it can't use imports after being bundled).:
![image](https://github.com/software-mansion/react-native-ide/assets/726445/80726904-7f90-4a4a-b33a-2e88be2d4b1a)

After changing require to import syntax, it appears like babel now understands that it needs to process imports and it processes all of them including the ones added by the compiler plugin which avoids the JS error thrown before the change:
<img width="580" alt="image" src="https://github.com/software-mansion/react-native-ide/assets/726445/584ec94a-300d-4298-8e36-1378fdad844d">
