### PR TITLE
docs: Remove Hire Us Container from subpages

### DIFF
--- a/packages/docs/src/css/overrides.css
+++ b/packages/docs/src/css/overrides.css
@@ -110,6 +110,9 @@ table thead tr {
 [class*="plugin-pages"] [class*="navbar__toggle"] {
   display: none;
 }
+[class*="plugin-pages"] [class*="hireUsContainer"] {
+  display: none;
+}
 
 nav [class*="_sidebarFooter"] {
   display: none;


### PR DESCRIPTION
Hire Us Container is redundant in `Privacy Policy`, `Terms Of Use` and `Refund Policy` subpages, so we decided to hide it there.

Before:
<img width="420" alt="image" src="https://github.com/software-mansion/react-native-ide/assets/59940332/48554e00-812d-4056-8913-dbe0d573f0a3">
<img width="420" alt="image" src="https://github.com/software-mansion/react-native-ide/assets/59940332/4614f9e6-74fd-4aef-be93-f8b541593f4b">
<img width="420" alt="image" src="https://github.com/software-mansion/react-native-ide/assets/59940332/93b304c9-23a3-4d79-850d-59c68914fc33">


After:
<img width="420" alt="image" src="https://github.com/software-mansion/react-native-ide/assets/59940332/0f5a61d7-b0bd-41f4-b3af-02773edeb377">
<img width="420" alt="image" src="https://github.com/software-mansion/react-native-ide/assets/59940332/adaadf75-8cb1-4166-a4ed-a524ec1212aa">
<img width="420" alt="image" src="https://github.com/software-mansion/react-native-ide/assets/59940332/2d618c80-972b-46bd-a257-5ad8fad49674">

