### PR TITLE
Improve detection whether we should use Expo CLI

### DIFF
--- a/packages/docs/docs/launch-configuration.md
+++ b/packages/docs/docs/launch-configuration.md
@@ -133,6 +133,7 @@ Here, we list other attributes that can be configured using launch configuration
   IDE is launching.
 - `metroConfigPath` — Path to metro config relative to the workspace. By default it tries to find
   `metro.config.js` or `metro.config.ts`.
+- `isExpo` — Boolean that can be set to `true` if IDE doesn't automatically detect the project should use Expo CLI. By default, the IDE tries to detect whether project is Expo-base or based on the React Native community CLI, so in most of the cases this options shouldn't be needed.
 
 Below is a sample `launch.json` config file with `appRoot`, `metroConfigPath`, and `env` setting specified:
 

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -162,6 +162,10 @@
                 "type": "string",
                 "description": "Location of the React Native application root folder relative to the workspace. This is used for monorepo type setups when the workspace root is not the root of the React Native project. The IDE extension tries to locate the React Native application root automatically, but in case it failes to do so (i.e. there are multiple applications defined in the workspace), you can use this setting to override the location."
               },
+              "isExpo": {
+                "type": "boolean",
+                "description": "IDE tries to detect whether project uses Expo or React Native community CLI. This is needed when starting the bundler. If your project uses Expo but IDE fails to automatically detect it, you can set this parameter to `true` to force the use of Expo CLI."
+              },
               "env": {
                 "type": "object",
                 "description": "Environment variables to be passed to all build/run commands that the IDE is launching."

--- a/packages/vscode-extension/src/project/metro.ts
+++ b/packages/vscode-extension/src/project/metro.ts
@@ -268,23 +268,37 @@ function findCustomMetroConfig(configPath: string) {
 }
 
 function shouldUseExpoCLI() {
-  // for expo launcher we use expo_start.js script that override some metro settings since it is not possible to
-  // do that by passing command line option like in the case of community CLI's packager script.
-  // we need to be able to detect whether the given project should use expo-flavored bundler or not.
-  // we assume (and this seem to be working in projects we have tested so far), that if expo CLI is available, the project
-  // is either using expo CLI, or it doesn't make a different for the development bundle whether we use expo bundler or not.
+  // The mechanism for detecting whether the project should use Expo CLI or React Native Community CLI works as follows:
+  // We check launch configuration, which has an option to force Expo CLI, we verify that first and if it is set to true we use Expo CLI.
+  // When the Expo option isn't set, we need all of the below checks to be true in order to use Expo CLI:
+  // 1. expo cli package is present in the app's node_modules (we can resolve it using require.resolve)
+  // 2. package.json has expo scripts in it (i.e. "expo start" or "expo build" scripts are present in the scripts section of package.json)
+  // 3. the user doesn't use a custom metro config option – this is only available for RN CLI projects
+  const config = getLaunchConfiguration();
+  if (config.isExpo) {
+    return true;
+  }
 
-  // Since the location of expo package can be different depending on the project configuration, we use the technique here
-  // that relies on node's resolve mechanism. We try to resolve expo package in the app root folder, and if it resolves, we
-  // assume we can launch expo CLI bundler.
-  const appRootFolder = getAppRootFolder();
-  try {
-    return (
-      require.resolve("@expo/cli/build/src/start/index", {
-        paths: [appRootFolder],
-      }) !== undefined
-    );
-  } catch (e) {
+  if (config.metroConfigPath) {
     return false;
   }
+
+  const appRootFolder = getAppRootFolder();
+  let hasExpoCLIInstalled = false,
+    hasExpoCommandsInScripts = false;
+  try {
+    hasExpoCLIInstalled =
+      require.resolve("@expo/cli/build/src/start/index", {
+        paths: [appRootFolder],
+      }) !== undefined;
+  } catch (e) {}
+
+  try {
+    const packageJson = require(path.join(appRootFolder, "package.json"));
+    hasExpoCommandsInScripts = Object.values<string>(packageJson.scripts).some((script: string) => {
+      return script.includes("expo ");
+    });
+  } catch (e) {}
+
+  return hasExpoCLIInstalled && hasExpoCommandsInScripts;
 }

--- a/packages/vscode-extension/src/utilities/launchConfiguration.ts
+++ b/packages/vscode-extension/src/utilities/launchConfiguration.ts
@@ -8,6 +8,7 @@ export type LaunchConfigurationOptions = {
     scheme?: string;
     configuration?: string;
   };
+  isExpo?: boolean;
   android?: {
     buildType?: string;
     productFlavor?: string;


### PR DESCRIPTION
Fixes #318

This PR updates the way we detect whether project should use Expo CLI. There are two main changes here:
1) In addition for checking whether expo cli is installed, we also verify that scrtips section in package json contains some expo commands (like "expo start" etc)
2) We add launch configuration option for overriding this behavior and forcing the use of Expo CLI