### PR TITLE
Don't perform clean rebuild on bundle errors

### DIFF
--- a/packages/vscode-extension/src/webview/hooks/useBuildErrorAlert.tsx
+++ b/packages/vscode-extension/src/webview/hooks/useBuildErrorAlert.tsx
@@ -18,7 +18,7 @@ function Actions() {
       <IconButton
         type="secondary"
         onClick={() => {
-          project.restart(true);
+          project.restart(false);
         }}
         tooltip={{ label: "Reload IDE", side: "bottom" }}>
         <span className="codicon codicon-refresh" />


### PR DESCRIPTION
Bundle errors shouldn't require full rebuild to get fix as they are due to JS-only code changes. We shouldn't trigger clean builds from the bundle error dialog.