### PR TITLE
Kmagiera/selectable UI

### DIFF
--- a/packages/vscode-extension/src/webview/App.css
+++ b/packages/vscode-extension/src/webview/App.css
@@ -6,7 +6,6 @@ body,
   margin: 0;
   padding: 0;
   background-color: var(--swm-preview-background);
-  user-select: none;
 }
 
 main {

--- a/packages/vscode-extension/src/webview/App.css
+++ b/packages/vscode-extension/src/webview/App.css
@@ -6,6 +6,7 @@ body,
   margin: 0;
   padding: 0;
   background-color: var(--swm-preview-background);
+  user-select: none;
 }
 
 main {

--- a/packages/vscode-extension/src/webview/App.tsx
+++ b/packages/vscode-extension/src/webview/App.tsx
@@ -1,6 +1,5 @@
 import "./App.css";
 import PreviewView from "./views/PreviewView";
-import { useDiagnosticAlert } from "./hooks/useDiagnosticAlert";
 
 function App() {
   return (

--- a/packages/vscode-extension/src/webview/views/PreviewView.css
+++ b/packages/vscode-extension/src/webview/views/PreviewView.css
@@ -9,6 +9,10 @@
   gap: 4px;
 }
 
+.panel-view {
+  user-select: none;
+}
+
 .button-group-top {
   margin-bottom: 8px;
 }

--- a/packages/vscode-extension/src/webview/views/PreviewView.tsx
+++ b/packages/vscode-extension/src/webview/views/PreviewView.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, Dispatch, SetStateAction } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { vscode } from "../utilities/vscode";
 import Preview from "../components/Preview";
 import IconButton from "../components/shared/IconButton";


### PR DESCRIPTION
This PR disables user-select on most of the IDE panel UI. It's done because now it is easy to accidently select things on the panel including the simulator image. However, due to the fact we capture mouse events over simulator and prevent default behavior, it isn't easy to un-select things. It seems like there's not a lot of value in enabling user select on the main UI while people may still want to copy things like error messages from dialogs hence we disable it on the main panel level and allow it to work on popups and dialogs.