### PR TITLE
Update styles & content for Early bird license pricing card

### DIFF
--- a/packages/docs/src/components/Pricing/PricingPlansList/index.tsx
+++ b/packages/docs/src/components/Pricing/PricingPlansList/index.tsx
@@ -76,10 +76,13 @@ const PricingPlansList = () => {
           </div>
         </li>
         <li className={styles.item}>
-          <div className={clsx(styles.plan__container, styles.plan__highlight)}>
-            <h2 className={styles.plan__name}>
-              Early Bird <span className={styles.plan__special_offer}>One-time special offer</span>
-            </h2>
+          <div className={styles.plan__special_offer__wrapper}>
+            <div className={clsx(styles.plan__special_offer, styles.plan__highlight)}>
+              One-time special offer
+            </div>
+          </div>
+          <div className={styles.plan__container}>
+            <h2 className={styles.plan__name}>Early Bird</h2>
             <h3 className={styles.plan__price}>
               {isMonthly ? earlyBirdMonthly : earlyBirdAnnually}
             </h3>
@@ -87,11 +90,14 @@ const PricingPlansList = () => {
             <p>What's included:</p>
             <ul className={styles.plan__features}>
               <li>Everything in Individual</li>
-              <li>Freeze your price for the first year</li>
-              <li>License period starts Q3 2024, next billing Q3 2025</li>
-              <li>Early bird discount ends with Beta</li>
+              <li>Get access to direct chat with creators of IDE</li>
+              <li>Prioritized feature requests </li>
               <li>Support the development of IDE</li>
             </ul>
+            <p className={styles.plan__tagline}>
+              Freeze your price for the first year. License period starts Q3 2024, next billing Q3
+              2025. Early bird discount ends with Beta.
+            </p>
             <div className={styles.plan__spacer} />
             <Button href="/" disabled>
               Available early June

--- a/packages/docs/src/components/Pricing/PricingPlansList/styles.module.css
+++ b/packages/docs/src/components/Pricing/PricingPlansList/styles.module.css
@@ -27,17 +27,8 @@
   background-color: var(--swm-off-background);
 }
 
-.plan__highlight {
-  animation: highlight 2s infinite alternate ease-in-out;
-}
-
-@keyframes highlight {
-  0% {
-    box-shadow: 0px 0px 3px var(--swm-green-light-100);
-  }
-  100% {
-    box-shadow: 0px 0px 10px var(--swm-green-light-100);
-  }
+.plan__container ul {
+  padding-left: 24px;
 }
 
 .plan__name {
@@ -110,8 +101,36 @@
   font-weight: 400;
 }
 
+.plan__special_offer__wrapper {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+}
+
 .plan__special_offer {
   color: var(--swm-red-light-80);
+  position: absolute;
+  text-align: center;
+  background-color: var(--swm-red-light-20);
+  border-radius: 8px;
+  padding: 0 8px;
+  font-weight: bold;
+  font-size: 14px;
+  text-transform: uppercase;
+}
+
+.plan__highlight {
+  animation: highlight 2s infinite alternate ease-in-out;
+}
+
+@keyframes highlight {
+  0% {
+    box-shadow: 0px 0px 2px var(--swm-red-light-100);
+  }
+  100% {
+    box-shadow: 0px 0px 6px var(--swm-red-light-100);
+  }
 }
 
 .plan_pay_annually__discount {


### PR DESCRIPTION
## Before

<img width="767" alt="image" src="https://github.com/software-mansion/react-native-ide/assets/39658211/b8b01b4e-29e5-447c-a234-2bddcc1e71b5">

## After

<img width="813" alt="image" src="https://github.com/software-mansion/react-native-ide/assets/39658211/d995dfba-0dde-45e0-a443-611e5958d2a6">
