### PR TITLE
Introduce a cap for iOS build progress.

### DIFF
--- a/packages/vscode-extension/src/builders/BuildIOSProgressProcessor.ts
+++ b/packages/vscode-extension/src/builders/BuildIOSProgressProcessor.ts
@@ -65,7 +65,7 @@ export class BuildIOSProgressProcessor implements BuildProgressProcessor {
     if (!this.tasksToComplete) {
       return;
     }
-    this.progressListener(this.completedTasks / this.tasksToComplete);
+    this.progressListener(Math.min(1, this.completedTasks / this.tasksToComplete));
   }
 
   async processLine(line: string) {


### PR DESCRIPTION
This PR solves an issue with iOS build Progress sometimes exceeds 100%.

Before: 

https://github.com/software-mansion/react-native-ide/assets/159789821/46cc5390-eae8-4dff-9781-207180879ebb

After:

https://github.com/software-mansion/react-native-ide/assets/159789821/79413d55-270e-47b9-89ff-ba51d3bad249

***recordings were made during a build of the same bare react native template.



