### PR TITLE
Fix a range of webview resizing issues. 

### DIFF
--- a/packages/vscode-extension/src/common/Project.ts
+++ b/packages/vscode-extension/src/common/Project.ts
@@ -19,8 +19,10 @@ export type ProjectState = {
   stageProgress?: number;
   previewURL: string | undefined;
   selectedDevice: DeviceInfo | undefined;
-  previewZoom: number | "Fit" | undefined; // Preview specific. Consider extracting to different location if we store more preview state
+  previewZoom: ZoomLevelType | undefined; // Preview specific. Consider extracting to different location if we store more preview state
 };
+
+export type ZoomLevelType = { isFit: boolean; value: number };
 
 // important: order of values in this enum matters
 export enum StartupMessage {
@@ -88,7 +90,7 @@ export interface ProjectInterface {
   getProjectState(): Promise<ProjectState>;
   restart(forceCleanBuild: boolean): Promise<void>;
   selectDevice(deviceInfo: DeviceInfo): Promise<void>;
-  updatePreviewZoomLevel(zoom: number | "Fit"): Promise<void>;
+  updatePreviewZoomLevel(zoom: ZoomLevelType): Promise<void>;
 
   getDeviceSettings(): Promise<DeviceSettings>;
   updateDeviceSettings(deviceSettings: DeviceSettings): Promise<void>;

--- a/packages/vscode-extension/src/common/Project.ts
+++ b/packages/vscode-extension/src/common/Project.ts
@@ -22,7 +22,7 @@ export type ProjectState = {
   previewZoom: ZoomLevelType | undefined; // Preview specific. Consider extracting to different location if we store more preview state
 };
 
-export type ZoomLevelType = { isFit: boolean; value: number };
+export type ZoomLevelType = number | "Fit";
 
 // important: order of values in this enum matters
 export enum StartupMessage {

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -32,6 +32,7 @@ import stripAnsi from "strip-ansi";
 import { minimatch } from "minimatch";
 import { IosSimulatorDevice } from "../devices/IosSimulatorDevice";
 import { AndroidEmulatorDevice } from "../devices/AndroidEmulatorDevice";
+import { ZoomLevelType } from "../webview/components/ZoomControls";
 
 const DEVICE_SETTINGS_KEY = "device_settings";
 const LAST_SELECTED_DEVICE_KEY = "last_selected_device";
@@ -396,7 +397,7 @@ export class Project implements Disposable, MetroDelegate, ProjectInterface {
     }
   }
 
-  public async updatePreviewZoomLevel(zoom: number | "Fit"): Promise<void> {
+  public async updatePreviewZoomLevel(zoom: ZoomLevelType): Promise<void> {
     this.updateProjectState({ previewZoom: zoom });
     extensionContext.workspaceState.update(PREVIEW_ZOOM_KEY, zoom);
   }

--- a/packages/vscode-extension/src/webview/components/Preview.css
+++ b/packages/vscode-extension/src/webview/components/Preview.css
@@ -5,9 +5,9 @@
   align-items: safe center;
   overflow: auto;
   width: 100%;
+  /* height: 100%; */
   position: relative;
   user-select: none;
-  scrollbar-gutter: stable;
 }
 
 .phone-wrapper:hover,
@@ -18,8 +18,10 @@
 .phone-content {
   position: relative;
   display: flex;
-  height: 100%;
   aspect-ratio: var(--phone-aspect-ratio);
+  max-width: 100%;
+  max-height: 100%;
+  /* object-fit: scale-down; */
 }
 
 .touch-area {

--- a/packages/vscode-extension/src/webview/components/Preview.tsx
+++ b/packages/vscode-extension/src/webview/components/Preview.tsx
@@ -14,11 +14,11 @@ import PreviewLoader from "./PreviewLoader";
 import { useBuildErrorAlert, useBundleErrorAlert } from "../hooks/useBuildErrorAlert";
 import Debugger from "./Debugger";
 import { useNativeRebuildAlert } from "../hooks/useNativeRebuildAlert";
-import { InspectData, InspectDataStackItem } from "../../common/Project";
+import { InspectData, InspectDataStackItem, ZoomLevelType } from "../../common/Project";
 import { InspectDataMenu } from "./InspectDataMenu";
 import { Resizable } from "re-resizable";
 import { useResizableProps } from "../hooks/useResizableProps";
-import { ZoomLevelType } from "./ZoomControls";
+import ZoomControls from "./ZoomControls";
 
 declare module "react" {
   interface CSSProperties {
@@ -30,7 +30,6 @@ function cssPropertiesForDevice(device: DeviceProperties) {
   return {
     "--phone-screen-height": `${(device.screenHeight / device.frameHeight) * 100}%`,
     "--phone-screen-width": `${(device.screenWidth / device.frameWidth) * 100}%`,
-    "--min-height": `${650}px`,
     "--phone-aspect-ratio": `${device.frameWidth / device.frameHeight}`,
     "--phone-mask-image": `url(${device.maskImage})`,
     "--phone-top": `${(device.offsetY / device.frameHeight) * 100}%`,
@@ -323,118 +322,129 @@ function Preview({ isInspecting, setIsInspecting, zoomLevel, onZoomChanged }: Pr
     wrapperDivRef,
     zoomLevel,
     setZoomLevel: onZoomChanged,
+    device: device!,
   });
 
   return (
-    <div
-      className="phone-wrapper"
-      style={cssPropertiesForDevice(device!)}
-      tabIndex={0} // allows keyboard events to be captured
-      ref={wrapperDivRef}>
-      {showDevicePreview && (
-        <Resizable {...resizableProps}>
-          <div className="phone-content">
-            <div className="touch-area" {...touchHandlers}>
-              <MjpegImg
-                src={previewURL}
-                ref={previewRef}
-                style={{
-                  cursor: isInspecting ? "crosshair" : "default",
-                }}
-                className="phone-screen"
-              />
+    <>
+      <div
+        className="phone-wrapper"
+        style={cssPropertiesForDevice(device!)}
+        tabIndex={0} // allows keyboard events to be captured
+        ref={wrapperDivRef}>
+        {showDevicePreview && (
+          <Resizable {...resizableProps}>
+            <div className="phone-content">
+              <div className="touch-area" {...touchHandlers}>
+                <MjpegImg
+                  src={previewURL}
+                  ref={previewRef}
+                  style={{
+                    cursor: isInspecting ? "crosshair" : "default",
+                  }}
+                  className="phone-screen"
+                />
 
-              {inspectFrame && (
-                <div className="phone-screen phone-inspect-overlay">
-                  <div
-                    className="inspect-area"
-                    style={{
-                      left: `${inspectFrame.x * 100}%`,
-                      top: `${inspectFrame.y * 100}%`,
-                      width: `${inspectFrame.width * 100}%`,
-                      height: `${inspectFrame.height * 100}%`,
-                    }}
-                  />
-                </div>
-              )}
-              {projectStatus === "refreshing" && (
-                <div className="phone-screen phone-refreshing-overlay">
-                  <VSCodeProgressRing />
-                  <div>Refreshing...</div>
-                </div>
-              )}
-              {debugPaused && (
-                <div className="phone-screen phone-debug-overlay">
-                  <Debugger />
-                </div>
-              )}
-              {debugException && (
-                <div className="phone-screen phone-debug-overlay phone-exception-overlay">
-                  <button className="uncaught-button" onClick={() => project.resumeDebugger()}>
-                    Uncaught exception&nbsp;
-                    <span className="codicon codicon-debug-continue" />
-                  </button>
-                </div>
-              )}
-              {/* TODO: Add different label in case of bundle/incremental bundle error */}
-              {hasBundleError && (
-                <div className="phone-screen phone-debug-overlay phone-exception-overlay">
-                  <button
-                    className="uncaught-button"
-                    onClick={() => {
-                      project.restart(false);
-                    }}>
-                    Bundle error&nbsp;
-                    <span className="codicon codicon-refresh" />
-                  </button>
-                </div>
-              )}
-              {hasIncrementalBundleError && (
-                <div className="phone-screen phone-debug-overlay phone-exception-overlay">
-                  <button className="uncaught-button" onClick={() => project.restart(false)}>
-                    Bundle error&nbsp;
-                    <span className="codicon codicon-refresh" />
-                  </button>
-                </div>
+                {inspectFrame && (
+                  <div className="phone-screen phone-inspect-overlay">
+                    <div
+                      className="inspect-area"
+                      style={{
+                        left: `${inspectFrame.x * 100}%`,
+                        top: `${inspectFrame.y * 100}%`,
+                        width: `${inspectFrame.width * 100}%`,
+                        height: `${inspectFrame.height * 100}%`,
+                      }}
+                    />
+                  </div>
+                )}
+                {projectStatus === "refreshing" && (
+                  <div className="phone-screen phone-refreshing-overlay">
+                    <VSCodeProgressRing />
+                    <div>Refreshing...</div>
+                  </div>
+                )}
+                {debugPaused && (
+                  <div className="phone-screen phone-debug-overlay">
+                    <Debugger />
+                  </div>
+                )}
+                {debugException && (
+                  <div className="phone-screen phone-debug-overlay phone-exception-overlay">
+                    <button className="uncaught-button" onClick={() => project.resumeDebugger()}>
+                      Uncaught exception&nbsp;
+                      <span className="codicon codicon-debug-continue" />
+                    </button>
+                  </div>
+                )}
+                {/* TODO: Add different label in case of bundle/incremental bundle error */}
+                {hasBundleError && (
+                  <div className="phone-screen phone-debug-overlay phone-exception-overlay">
+                    <button
+                      className="uncaught-button"
+                      onClick={() => {
+                        project.restart(false);
+                      }}>
+                      Bundle error&nbsp;
+                      <span className="codicon codicon-refresh" />
+                    </button>
+                  </div>
+                )}
+                {hasIncrementalBundleError && (
+                  <div className="phone-screen phone-debug-overlay phone-exception-overlay">
+                    <button className="uncaught-button" onClick={() => project.restart(false)}>
+                      Bundle error&nbsp;
+                      <span className="codicon codicon-refresh" />
+                    </button>
+                  </div>
+                )}
+              </div>
+              <img src={device!.frameImage} className="phone-frame" />
+              {inspectStackData && (
+                <InspectDataMenu
+                  inspectLocation={inspectStackData.requestLocation}
+                  inspectStack={inspectStackData.stack}
+                  onSelected={onInspectorItemSelected}
+                  onHover={(item) => {
+                    if (item.frame) {
+                      setInspectFrame(item.frame);
+                    }
+                  }}
+                  onCancel={() => resetInspector()}
+                />
               )}
             </div>
-            <img src={device!.frameImage} className="phone-frame" />
-            {inspectStackData && (
-              <InspectDataMenu
-                inspectLocation={inspectStackData.requestLocation}
-                inspectStack={inspectStackData.stack}
-                onSelected={onInspectorItemSelected}
-                onHover={(item) => {
-                  if (item.frame) {
-                    setInspectFrame(item.frame);
-                  }
-                }}
-                onCancel={() => resetInspector()}
-              />
-            )}
-          </div>
-        </Resizable>
-      )}
-      {!showDevicePreview && !hasBuildError && (
-        <Resizable {...resizableProps}>
-          <div className="phone-content">
-            <div className="phone-sized phone-content-loading-background" />
-            <div className="phone-sized phone-content-loading ">
-              <PreviewLoader onRequestShowPreview={() => setShowPreviewRequested(true)} />
+          </Resizable>
+        )}
+        {!showDevicePreview && !hasBuildError && (
+          <Resizable {...resizableProps}>
+            <div className="phone-content">
+              <div className="phone-sized phone-content-loading-background" />
+              <div className="phone-sized phone-content-loading ">
+                <PreviewLoader onRequestShowPreview={() => setShowPreviewRequested(true)} />
+              </div>
+              <img src={device!.frameImage} className="phone-frame" />
             </div>
-            <img src={device!.frameImage} className="phone-frame" />
-          </div>
-        </Resizable>
-      )}
-      {hasBuildError && (
-        <Resizable {...resizableProps}>
-          <div className="phone-content">
-            <div className="phone-sized extension-error-screen" />
-            <img src={device!.frameImage} className="phone-frame" />
-          </div>
-        </Resizable>
-      )}
-    </div>
+          </Resizable>
+        )}
+        {hasBuildError && (
+          <Resizable {...resizableProps}>
+            <div className="phone-content">
+              <div className="phone-sized extension-error-screen" />
+              <img src={device!.frameImage} className="phone-frame" />
+            </div>
+          </Resizable>
+        )}
+      </div>
+      <div className="button-group-left">
+        <ZoomControls
+          zoomLevel={zoomLevel}
+          onZoomChanged={onZoomChanged}
+          device={device}
+          wrapperDivRef={wrapperDivRef}
+        />
+      </div>
+    </>
   );
 }
 

--- a/packages/vscode-extension/src/webview/components/UrlSelect.css
+++ b/packages/vscode-extension/src/webview/components/UrlSelect.css
@@ -18,14 +18,15 @@
   color: var(--swm-url-select);
   background-color: var(--swm-url-select-background);
   user-select: none;
-  min-width: var(--url-select-min-width);
+  /* min-width: var(--url-select-min-width);  */
   max-width: var(--url-select-max-width);
 }
 .url-select-trigger:hover {
   background-color: var(--swm-url-select-hover-background);
 }
 .url-select-trigger[data-state="open"] {
-  border-radius: 18px 18px 0 0;
+  border-radius: 18px 18px 18px 18px;
+  box-shadow: var(--swm-focus-outline);
 }
 .url-select-trigger[data-disabled] {
   background-color: var(--swm-url-select-disabled-background);
@@ -39,7 +40,8 @@
 .url-select-content {
   overflow: hidden;
   background-color: var(--swm-url-select-background);
-  border-radius: 0 0 18px 18px;
+  border-radius: 18px 18px 18px 18px;
+  transform: translateY(4px);
   padding-bottom: 4px;
   min-width: var(--url-select-min-width);
   max-width: var(--url-select-max-width);

--- a/packages/vscode-extension/src/webview/components/ZoomControls.tsx
+++ b/packages/vscode-extension/src/webview/components/ZoomControls.tsx
@@ -21,10 +21,10 @@ const ZoomLevelSelect = ({ zoomLevel, onZoomChanged }: ZoomControlsProps) => {
   const onValueChange = useCallback(
     (e: string) => {
       if (e == "Fit") {
-        onZoomChanged({ isFit: true, value: zoomLevel.value ?? DEFAULT_ZOOM_LEVEL });
+        onZoomChanged("Fit");
         return;
       }
-      onZoomChanged({ isFit: false, value: Number(e) });
+      onZoomChanged(Number(e));
     },
     [onZoomChanged]
   );
@@ -32,10 +32,10 @@ const ZoomLevelSelect = ({ zoomLevel, onZoomChanged }: ZoomControlsProps) => {
   return (
     <Select.Root
       onValueChange={onValueChange}
-      value={zoomLevel.isFit ? "Fit" : zoomLevel.value.toString()}>
+      value={zoomLevel === "Fit" ? "Fit" : zoomLevel.toString()}>
       <Select.Trigger className="zoom-select-trigger" disabled={false}>
         <Select.Value>
-          <div className="zoom-select-value">{zoomLevel.isFit ? "Fit" : `${zoomLevel.value}x`}</div>
+          <div className="zoom-select-value">{zoomLevel === "Fit" ? "Fit" : `${zoomLevel}x`}</div>
         </Select.Value>
       </Select.Trigger>
 
@@ -64,17 +64,17 @@ const ZoomLevelSelect = ({ zoomLevel, onZoomChanged }: ZoomControlsProps) => {
 function ZoomControls({ zoomLevel, onZoomChanged, device, wrapperDivRef }: ZoomControlsProps) {
   function handleZoom(shouldIncrease: boolean) {
     let currentZoomLevel;
-    if (zoomLevel.isFit) {
+    if (zoomLevel === "Fit") {
       currentZoomLevel =
         ((wrapperDivRef!.current!.offsetHeight / device!.frameHeight) * 1) / DEVICE_DEFAULT_SCALE;
     } else {
-      currentZoomLevel = zoomLevel.value;
+      currentZoomLevel = zoomLevel;
     }
     // toFixed() is necessary because of floating point rounding errors
     const newZoomLevel = +(currentZoomLevel + (shouldIncrease ? ZOOM_STEP : -ZOOM_STEP)).toFixed(2);
 
     if (newZoomLevel >= ZOOM_STEP) {
-      onZoomChanged({ isFit: false, value: newZoomLevel });
+      onZoomChanged(newZoomLevel);
     }
   }
 

--- a/packages/vscode-extension/src/webview/hooks/useResizableProps.tsx
+++ b/packages/vscode-extension/src/webview/hooks/useResizableProps.tsx
@@ -1,11 +1,14 @@
 import { ResizeCallback } from "re-resizable";
-import { CSSProperties, useCallback, useEffect, useState } from "react";
-import { ZoomLevelType } from "../components/ZoomControls";
+import { CSSProperties, useCallback, useEffect, useRef, useState } from "react";
+import { DeviceProperties } from "../utilities/consts";
+import { ZoomLevelType } from "../../common/Project";
+import { DEVICE_DEFAULT_SCALE } from "../components/ZoomControls";
 
 type UseResizableProps = {
   wrapperDivRef: React.RefObject<HTMLDivElement>;
   zoomLevel: ZoomLevelType;
   setZoomLevel: (zoomLevel: ZoomLevelType) => void;
+  device: DeviceProperties;
 };
 
 const defaultResizableStyle: CSSProperties = {
@@ -14,28 +17,26 @@ const defaultResizableStyle: CSSProperties = {
 
 type PhoneHeight = number | `${number}%`;
 
-export function useResizableProps({ wrapperDivRef, zoomLevel, setZoomLevel }: UseResizableProps) {
+export function useResizableProps({
+  wrapperDivRef,
+  zoomLevel,
+  setZoomLevel,
+  device,
+}: UseResizableProps) {
   const [phoneHeight, setPhoneHeight] = useState<PhoneHeight>(0);
+
+  const [maxWidth, setMaxWidth] = useState<"100%" | undefined>(undefined);
   const [resizableStyle, setResizableStyle] = useState<CSSProperties>(defaultResizableStyle);
 
-  const calculateZoomLevel = useCallback(() => {
-    if (phoneHeight === 0 || typeof phoneHeight === "string") {
-      return;
-    }
-
-    const wrapperHeight = wrapperDivRef.current!.offsetHeight;
-    setZoomLevel(Math.round((phoneHeight * 100) / wrapperHeight));
-  }, [wrapperDivRef, phoneHeight, setZoomLevel]);
-
-  const calculatePhoneHeight = useCallback(
+  const calculatePhoneDimensions = useCallback(
     (delta = 0) => {
-      if (zoomLevel === "Fit") {
+      if (zoomLevel.isFit) {
         setPhoneHeight("100%");
+        setMaxWidth("100%");
         return;
       }
-
-      const wrapperHeight = wrapperDivRef.current!.offsetHeight;
-      setPhoneHeight(wrapperHeight * (zoomLevel / 100) + delta);
+      setPhoneHeight(device.frameHeight * zoomLevel.value * DEVICE_DEFAULT_SCALE + delta);
+      setMaxWidth(undefined);
     },
     [wrapperDivRef, zoomLevel]
   );
@@ -44,21 +45,13 @@ export function useResizableProps({ wrapperDivRef, zoomLevel, setZoomLevel }: Us
 
   const onResizeStop: ResizeCallback = useCallback(
     (event, direction, ref, delta) => {
-      calculatePhoneHeight(delta.height);
-      calculateZoomLevel();
+      calculatePhoneDimensions(delta.height);
       setResizableStyle(defaultResizableStyle);
     },
     [resizableStyle]
   );
 
-  useEffect(() => {
-    const resizeObserver = new ResizeObserver(calculateZoomLevel);
-    resizeObserver.observe(wrapperDivRef.current!);
-
-    return () => resizeObserver.disconnect();
-  }, [wrapperDivRef, calculateZoomLevel]);
-
-  useEffect(calculatePhoneHeight, [zoomLevel]);
+  useEffect(calculatePhoneDimensions, [zoomLevel]);
 
   return {
     size: { width: "auto", height: phoneHeight },
@@ -66,13 +59,18 @@ export function useResizableProps({ wrapperDivRef, zoomLevel, setZoomLevel }: Us
     onResizeStop,
     lockAspectRatio: true,
     // Setting display to "none" when phoneHeight is 0 to avoid the visible size transition
-    style: { ...resizableStyle, display: phoneHeight === 0 ? "none" : "initial" },
+    style: {
+      ...resizableStyle,
+      display: phoneHeight === 0 ? "none" : "flex",
+      alignItems: "center",
+    },
     handleStyles: {
       bottomRight: {
         right: 0,
         bottom: 0,
       },
     },
+    maxWidth,
     enable: {
       top: false,
       right: false,

--- a/packages/vscode-extension/src/webview/hooks/useResizableProps.tsx
+++ b/packages/vscode-extension/src/webview/hooks/useResizableProps.tsx
@@ -30,12 +30,12 @@ export function useResizableProps({
 
   const calculatePhoneDimensions = useCallback(
     (delta = 0) => {
-      if (zoomLevel.isFit) {
+      if (zoomLevel === "Fit") {
         setPhoneHeight("100%");
         setMaxWidth("100%");
         return;
       }
-      setPhoneHeight(device.frameHeight * zoomLevel.value * DEVICE_DEFAULT_SCALE + delta);
+      setPhoneHeight(device.frameHeight * zoomLevel * DEVICE_DEFAULT_SCALE + delta);
       setMaxWidth(undefined);
     },
     [wrapperDivRef, zoomLevel]

--- a/packages/vscode-extension/src/webview/views/PreviewView.css
+++ b/packages/vscode-extension/src/webview/views/PreviewView.css
@@ -1,16 +1,10 @@
 .button-group-top,
 .button-group-bottom {
   display: flex;
-  flex-flow: row wrap;
   align-items: center;
   width: 100%;
-
   margin: 10px;
   gap: 4px;
-}
-
-.panel-view {
-  user-select: none;
 }
 
 .button-group-top {

--- a/packages/vscode-extension/src/webview/views/PreviewView.tsx
+++ b/packages/vscode-extension/src/webview/views/PreviewView.tsx
@@ -16,14 +16,14 @@ import { useProject } from "../providers/ProjectProvider";
 import DeviceSelect from "../components/DeviceSelect";
 import Button from "../components/shared/Button";
 import { VSCodeProgressRing } from "@vscode/webview-ui-toolkit/react";
-import ZoomControls, { ZoomLevelType } from "../components/ZoomControls";
 import { useDiagnosticAlert } from "../hooks/useDiagnosticAlert";
+import { ZoomLevelType } from "../../common/Project";
 
 function PreviewView() {
   const { projectState, project } = useProject();
 
   const [isInspecting, setIsInspecting] = useState(false);
-  const zoomLevel = projectState.previewZoom ?? "Fit";
+  const zoomLevel = projectState.previewZoom ?? { isFit: true, value: 1 };
   const onZoomChanged = useCallback(
     (zoom: ZoomLevelType) => {
       project.updatePreviewZoomLevel(zoom);
@@ -36,6 +36,7 @@ function PreviewView() {
   const { devices, finishedInitialLoad } = useDevices();
 
   const selectedDevice = projectState?.selectedDevice;
+
   const devicesNotFound = projectState !== undefined && devices.length === 0;
 
   const { openModal } = useModal();
@@ -154,9 +155,6 @@ function PreviewView() {
           {devicesNotFound ? <DevicesNotFoundView /> : <VSCodeProgressRing />}
         </div>
       )}
-      <div className="button-group-left">
-        <ZoomControls zoomLevel={zoomLevel} onZoomChanged={onZoomChanged} />
-      </div>
 
       <div className="button-group-bottom">
         <IconButton

--- a/packages/vscode-extension/src/webview/views/PreviewView.tsx
+++ b/packages/vscode-extension/src/webview/views/PreviewView.tsx
@@ -23,7 +23,7 @@ function PreviewView() {
   const { projectState, project } = useProject();
 
   const [isInspecting, setIsInspecting] = useState(false);
-  const zoomLevel = projectState.previewZoom ?? { isFit: true, value: 1 };
+  const zoomLevel = projectState.previewZoom ?? "Fit";
   const onZoomChanged = useCallback(
     (zoom: ZoomLevelType) => {
       project.updatePreviewZoomLevel(zoom);

--- a/packages/vscode-extension/src/webview/views/View.css
+++ b/packages/vscode-extension/src/webview/views/View.css
@@ -7,4 +7,5 @@
   align-items: center;
   width: 100%;
   height: 100%;
+  user-select: none;
 }


### PR DESCRIPTION
This PR fixes problems related to width of the webview: 
1) "Fit" functionality of zoom controls now fits the device to booth, width and hight of the container, instead of just hight.
2) top and bottom menus no longer warp, but url bar changes the size instead. To account for the change dropdown menu triggered by url bar is now visually separated  from the url bar itself. 

on top of the above changes this PR changes the behavior of x1 zoom level from dynamically meaning "fit the container" to meaning the constant original size of the phone.  