### PR TITLE
Replace disabled magnet with home button used e.g. for getting back from preview mode.

### DIFF
--- a/packages/vscode-extension/src/common/Project.ts
+++ b/packages/vscode-extension/src/common/Project.ts
@@ -89,6 +89,7 @@ export interface ProjectEventListener<T> {
 export interface ProjectInterface {
   getProjectState(): Promise<ProjectState>;
   restart(forceCleanBuild: boolean): Promise<void>;
+  goHome(): Promise<void>;
   selectDevice(deviceInfo: DeviceInfo): Promise<void>;
   updatePreviewZoomLevel(zoom: ZoomLevelType): Promise<void>;
 

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -189,6 +189,10 @@ export class Project implements Disposable, MetroDelegate, ProjectInterface {
     this.metro?.reload();
   }
 
+  public async goHome() {
+    this.reloadMetro();
+  }
+
   public async restart(forceCleanBuild: boolean) {
     this.updateProjectState({ status: "starting", startupMessage: StartupMessage.Restarting });
     if (forceCleanBuild || this.nativeFilesChangedSinceLastBuild) {

--- a/packages/vscode-extension/src/webview/components/UrlBar.tsx
+++ b/packages/vscode-extension/src/webview/components/UrlBar.tsx
@@ -56,6 +56,15 @@ function UrlBar({ project, disabled }: UrlBarProps) {
         disabled={disabled}>
         <span className="codicon codicon-refresh" />
       </IconButton>
+      <IconButton
+        onClick={() => project.goHome()}
+        tooltip={{
+          label: "Go to main screen",
+          side: "bottom",
+        }}
+        disabled={disabled || urlList.length == 0}>
+        <span className="codicon codicon-home" />
+      </IconButton>
       <UrlSelect
         onValueChange={(value: string) => {
           project.openNavigation(value);

--- a/packages/vscode-extension/src/webview/views/PreviewView.tsx
+++ b/packages/vscode-extension/src/webview/views/PreviewView.tsx
@@ -95,27 +95,6 @@ function PreviewView() {
   return (
     <div className="panel-view">
       <div className="button-group-top">
-        <IconButton
-          tooltip={{
-            label: "Follow active editor on the device",
-            side: "bottom",
-          }}
-          active={isFollowing}
-          onClick={() => {
-            vscode.postMessage({
-              command: isFollowing ? "stopFollowing" : "startFollowing",
-            });
-            setIsFollowing(!isFollowing);
-          }}
-          disabled={
-            devicesNotFound ||
-            true /* for the time being we are disabling this functionality as it incurs some performance overhead we didn't yet have time to investigate */
-          }>
-          <span className="codicon codicon-magnet" />
-        </IconButton>
-
-        <span className="group-separator" />
-
         <UrlBar project={project} disabled={devicesNotFound} />
 
         <div className="spacer" />


### PR DESCRIPTION
When using component preview in non expo-router projects, there is no way in the panel to go back to the main app from preview mode. Since we are not currently using the magnet functionality, I decided we could add "home" button that's similar to what browsers offer, and hence would provide an intuitive way of going back home from preview mode.

Since it sort-of doubles the reload functionality, we disable it unless url list is non-empty. This happens specifically when preview is opened (previews get appended to url list). But home button can also be used in expo-router projects to reset the stack to /