### PR TITLE
Fix errors caused by #317

### DIFF
--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -24,6 +24,7 @@ import {
   ProjectInterface,
   ProjectState,
   StartupMessage,
+  ZoomLevelType,
 } from "../common/Project";
 import { EventEmitter } from "stream";
 import { openFileAtPosition } from "../utilities/openFileAtPosition";
@@ -32,9 +33,8 @@ import stripAnsi from "strip-ansi";
 import { minimatch } from "minimatch";
 import { IosSimulatorDevice } from "../devices/IosSimulatorDevice";
 import { AndroidEmulatorDevice } from "../devices/AndroidEmulatorDevice";
-import { ZoomLevelType } from "../webview/components/ZoomControls";
 
-const DEVICE_SETTINGS_KEY = "device_settings";
+const DEVICE_SETTINGS_KEY = "device_settings_v15";
 const LAST_SELECTED_DEVICE_KEY = "last_selected_device";
 const PREVIEW_ZOOM_KEY = "preview_zoom";
 
@@ -68,7 +68,7 @@ export class Project implements Disposable, MetroDelegate, ProjectInterface {
     location: {
       latitude: 50.048653,
       longitude: 19.965474,
-      isDisabled: false,
+      isDisabled: true,
     },
   };
 

--- a/packages/vscode-extension/src/webview/components/ZoomControls.tsx
+++ b/packages/vscode-extension/src/webview/components/ZoomControls.tsx
@@ -6,7 +6,6 @@ import { ZoomLevelType } from "../../common/Project";
 import { DeviceProperties } from "../utilities/consts";
 
 const ZOOM_STEP = 0.05;
-const DEFAULT_ZOOM_LEVEL = 1;
 const ZOOM_SELECT_NUMERIC_VALUES = [0.5, 0.6, 0.7, 0.8, 0.9, 1];
 export const DEVICE_DEFAULT_SCALE = 1 / 3;
 


### PR DESCRIPTION
In #317 new fields have been added to device settings. However, since we persist device settings, the changes are not compatible with the old data that might've been stored there. To prevent this we are adding a versioning of device settings key (will increment version with future changes).

This PR also changes the defaults to use disabled location, especially that we need to have some coordinates specified, it'd be weird to have everyone using IDE pointing to the same geo location.