### PR TITLE
Add failsafe mechanism for cloning sim-server binary

### DIFF
--- a/packages/vscode-extension/src/devices/preview.ts
+++ b/packages/vscode-extension/src/devices/preview.ts
@@ -15,7 +15,11 @@ export class Preview implements Disposable {
   }
 
   async start() {
-    const simControllerBinary = path.join(extensionContext.extensionPath, "dist", "sim-server");
+    const simControllerBinary = path.join(
+      extensionContext.extensionPath,
+      "dist",
+      "sim-server-executable"
+    );
 
     Logger.debug(`Launch preview ${simControllerBinary} ${this.args}`);
     const subprocess = exec(simControllerBinary, this.args, { buffer: false });

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -74,7 +74,12 @@ export async function activate(context: ExtensionContext) {
     enableDevModeLogging();
   }
 
-  await fixBinaries(context);
+  try {
+    await fixBinaries(context);
+  } catch (error) {
+    Logger.error("Error when processing simulator-server binaries", error);
+    // we let the activation continue, as otherwise the diagnostics command would fail
+  }
 
   commands.executeCommand("setContext", "RNIDE.sidePanelIsClosed", false);
 
@@ -296,28 +301,19 @@ async function fixBinaries(context: ExtensionContext) {
   // MacOS prevents binary files from being executed when downloaded from the internet.
   // It requires notarization ticket to be available in the package where the binary was distributed
   // with. Apparently Apple does not allow for individual binary files to be notarized and only .app/.pkg and .dmg
-  // files are allows. To prevent the binary from being quarantined, we clone it to a temporary file and then
-  // move it back to the original location. This way the quarantine attribute is removed.
-  // We try to do it only when the binary has been modified or for new installation, we detect it based
-  // on the modification date of the binary file.
-  const binModiticationDate = context.globalState.get(BIN_MODIFICATION_DATE_KEY);
-  const binPath = Uri.file(context.asAbsolutePath("dist/sim-server"));
-  const tmpFile = Uri.file(path.join(os.tmpdir(), "sim-server"));
+  // files are allowed. To prevent the binary from being quarantined, we clone using byte-copy (with dd). This way the
+  // quarantine attribute is removed. We try to do it only when the binary has been modified or for the new installation,
+  // we detect that based on the modification date of the binary file.
+  const buildBinPath = Uri.file(context.asAbsolutePath("dist/sim-server"));
+  const exeBinPath = Uri.file(context.asAbsolutePath("dist/sim-server-executable"));
 
-  if (binModiticationDate !== undefined) {
-    const binStats = await workspace.fs.stat(binPath);
-    if (binStats?.mtime === binModiticationDate) {
-      return;
-    }
+  // if build and exe binaries don't match, we need to clone the build binary – we always want the exe one to the exact
+  // copy of the build binary:
+  try {
+    await command(`diff -q ${buildBinPath.fsPath} ${exeBinPath.fsPath}`);
+  } catch (error) {
+    // if binaries are different, diff will return non-zero code and we will land in catch clouse
+    await command(`dd if=${buildBinPath.fsPath} of=${exeBinPath.fsPath}`);
+    await fs.promises.chmod(exeBinPath.fsPath, 0o755);
   }
-
-  // if the modification date is not set or the binary has been modified since copied, we clone the binary
-  // using `dd` command to remove the quarantine attribute
-  await command(`dd if=${binPath.fsPath} of=${tmpFile.fsPath}`);
-  await workspace.fs.delete(binPath);
-  await workspace.fs.rename(tmpFile, binPath);
-  await fs.promises.chmod(binPath.fsPath, 0o755);
-
-  const binStats = await workspace.fs.stat(binPath);
-  context.globalState.update(BIN_MODIFICATION_DATE_KEY, binStats?.mtime);
 }

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -314,6 +314,6 @@ async function fixBinaries(context: ExtensionContext) {
   } catch (error) {
     // if binaries are different, diff will return non-zero code and we will land in catch clouse
     await command(`dd if=${buildBinPath.fsPath} of=${exeBinPath.fsPath}`);
-    await fs.promises.chmod(exeBinPath.fsPath, 0o755);
   }
+  await fs.promises.chmod(exeBinPath.fsPath, 0o755);
 }

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -34,7 +34,7 @@ import { minimatch } from "minimatch";
 import { IosSimulatorDevice } from "../devices/IosSimulatorDevice";
 import { AndroidEmulatorDevice } from "../devices/AndroidEmulatorDevice";
 
-const DEVICE_SETTINGS_KEY = "device_settings_v15";
+const DEVICE_SETTINGS_KEY = "device_settings_v2";
 const LAST_SELECTED_DEVICE_KEY = "last_selected_device";
 const PREVIEW_ZOOM_KEY = "preview_zoom";
 


### PR DESCRIPTION
When debugging IDE with some users I noticed a strange setup in which the IDE ended up in a state with no sim-server binary. We couldn't get to the bottom of this issue, as subsequent installation went through, but decided to add a more failsafe mechanism for this procedure to prevent similar issue in the future or at least to let us investigate it better.

The problem:
Before we'd "fix" sim-server binary by copying it first to temp location and then using `dd` moving it back to original path. When some of the commands would fail, we could end up with the sim-server binary completely deleted and subsequent runs wouldn't allow for recovery as there was no way to retry it once it's deleted. Furthermore, reinstalling the extension didn't help in those scenarios as it doesn't delete installation dir and so long the version doesn't change, vscode won't download/unpack the new package.

The solution:
1) we now allow activation to continue despite error in binary fixing step. This way people will at least be able to access diagnostics and will get more meaningful errors once they attempt to spawn a simulator.
2) we also use an alternative path for executable binary. Such that instead of deleting sim-server and then copying it back from temp location, we only perform one copy to a new location. This way if the copy fails, we can safly retry it next time the extension is run.

