### PR TITLE
Override PWD variable when launching subprocess from different directory

### DIFF
--- a/packages/vscode-extension/src/project/metro.ts
+++ b/packages/vscode-extension/src/project/metro.ts
@@ -169,7 +169,7 @@ export class Metro implements Disposable {
           reject(new Error("Metro exited but did not start server successfully."));
         });
 
-      lineReader(bundlerProcess).onLineRead((line) => {
+      lineReader(bundlerProcess, true).onLineRead((line) => {
         try {
           const event = JSON.parse(line) as MetroEvent;
           if (event.type === "bundle_transform_progressed") {

--- a/packages/vscode-extension/src/utilities/subprocess.ts
+++ b/packages/vscode-extension/src/utilities/subprocess.ts
@@ -4,6 +4,17 @@ import readline from "readline";
 
 export type ChildProcess = ExecaChildProcess<string>;
 
+function updatePWDEnvWhenCwdIsSet(options: execa.Options) {
+  // Some processes rely on PWD environment variable that may be copied from
+  // the parent process. However, when cwd option is set, we never should use
+  // PWD of the parent process as it may point to a different directory. In case
+  // both cwd and PWD environment variable are set, we should update PWD to the
+  // same location as requested by the cwd option.
+  if (options.cwd && options.env && options.env.PWD) {
+    options.env.PWD = options.cwd;
+  }
+}
+
 /**
  * When using this methid, the subprocess should be started with buffer: false option
  * as there's no need for allocating memory for the output that's going to be very long.
@@ -35,6 +46,9 @@ export function lineReader(childProcess: ExecaChildProcess<string>, includeStder
 export function exec(
   ...args: [string, string[]?, (execa.Options & { allowNonZeroExit?: boolean })?]
 ) {
+  if (args.length > 1) {
+    updatePWDEnvWhenCwdIsSet(args[2]!);
+  }
   const subprocess = execa(...args);
   const allowNonZeroExit = args[2]?.allowNonZeroExit;
   async function printErrorsOnExit() {
@@ -72,6 +86,9 @@ export function exec(
 }
 
 export function execSync(...args: [string, string[]?, execa.SyncOptions?]) {
+  if (args.length > 1) {
+    updatePWDEnvWhenCwdIsSet(args[2]!);
+  }
   const result = execa.sync(...args);
   if (result.stderr) {
     Logger.debug(
@@ -86,6 +103,9 @@ export function execSync(...args: [string, string[]?, execa.SyncOptions?]) {
 }
 
 export function command(...args: [string, execa.Options?]) {
+  if (args.length > 1) {
+    updatePWDEnvWhenCwdIsSet(args[1]!);
+  }
   const subprocess = execa.command(...args);
   async function printErrorsOnExit() {
     try {


### PR DESCRIPTION
This PR fixes an issue with some modules that use the following pattern for accessing the project directory: https://github.com/zoontek/react-native-bootsplash/blob/master/src/generate.ts#L23

In that pattern PWD env variable takes precedence over process.cwd. However, this PWD variable may be inherited from the parent process and should not be passed down to child process when launched with cwd option.

This PR fixes this problem, by overriding PWD variable to point to cwd varlue when both are set. We also add stderr reading to metro subprocess such that it outputs error messages to the IDE logger.