### PR TITLE
Remove .gradle directories from fingerprint

### DIFF
--- a/packages/vscode-extension/src/utilities/fingerprint.ts
+++ b/packages/vscode-extension/src/utilities/fingerprint.ts
@@ -9,6 +9,7 @@ const IGNORE_PATHS = [
   path.join("android", "app", "build/**/*"),
   path.join("ios", "build/**/*"),
   "**/node_modules/**/android/.cxx/**/*",
+  "**/node_modules/**/.gradle/**/*",
   "**/node_modules/**/android/build/intermediates/cxx/**/*",
 ];
 


### PR DESCRIPTION
`expo-dev-launcher` in particular modifies its node_modules files, adding locks such as `app/node_modules/expo-dev-launcher/expo-dev-launcher-gradle-plugin/.gradle/buildOutputCleanup/buildOutputCleanup.lock`.

They change from launch to launch, modifying entire fingerprint.

Found by using `diffFingerprints` between last and current fingerprint, then utilizing `fswatch` to find offending files.
Tested by changing JS code in the [expo app](https://github.com/expo/react-conf-app).