### PR TITLE
Delay setting error handlers until debugger is connected

### DIFF
--- a/packages/vscode-extension/lib/runtime.js
+++ b/packages/vscode-extension/lib/runtime.js
@@ -12,9 +12,13 @@ function __RNIDE_breakOnError(error, isFatal) {
   debugger;
 }
 
-global.ErrorUtils.setGlobalHandler(__RNIDE_breakOnError);
-
-global.__fbDisableExceptionsManager = true;
+global.__RNIDE_onDebuggerConnected = function () {
+  // install error handler that breaks into the debugger but only do it when
+  // debugger is connected. Otherwise we may miss some important initialization
+  // errors or even pause the app execution before the debugger is attached.
+  global.ErrorUtils.setGlobalHandler(__RNIDE_breakOnError);
+  global.__fbDisableExceptionsManager = true;
+};
 
 function wrapConsole(consoleFunc) {
   return function (...args) {

--- a/packages/vscode-extension/src/debugging/DebugAdapter.ts
+++ b/packages/vscode-extension/src/debugging/DebugAdapter.ts
@@ -93,6 +93,9 @@ export class DebugAdapter extends DebugSession {
       this.sendCDPMessage("Debugger.setAsyncCallStackDepth", { maxDepth: 32 });
       this.sendCDPMessage("Debugger.setBlackboxPatterns", { patterns: [] });
       this.sendCDPMessage("Runtime.runIfWaitingForDebugger", {});
+      this.sendCDPMessage("Runtime.evaluate", {
+        expression: "__RNIDE_onDebuggerConnected()",
+      });
     });
 
     this.connection.on("close", () => {


### PR DESCRIPTION
This PR changes the way we override error handlers in our RN runtime.

Before, we'd register error handlers in initialization code, now we only do that once the debugger is connected.

The issue with the old approach was that in the case when there is some uncaught exception in the init phase, it'd go into our custom handler that'd stop the debugger. In that case we'd never be able to dispatch app-ready and hence the debugger would never connect.

In this PR we use CDP `Runtime.evaluate` to call new global handler `RNIDE_onDebuggerConnected` that is then used by the runtime to install error handlers. With this change in, initialization errors won't be caught in the debugger but they also won't freeze the app entirely w/o any clue.