### PR TITLE
Revert changes from #316 for expo-router v2 implementation

### DIFF
--- a/packages/vscode-extension/lib/expo_router_v2_plugin.js
+++ b/packages/vscode-extension/lib/expo_router_v2_plugin.js
@@ -34,8 +34,7 @@ function useRouterPluginMainHook({ onNavigationChange }) {
       };
     },
     requestNavigationChange: ({ pathname, params }) => {
-      router.navigate(pathname);
-      router.setParams(params);
+      router.push(pathname, params);
     },
   };
 }


### PR DESCRIPTION
In #316 we introduced a regression with expo-router v2 integration. The used `router.navigate` method is only available in v3 and hence we revert that modification change for expo-router v2 plugin. This PR effectively reverts changes from #316 made to packages/vscode-extension/lib/expo_router_v2_plugin.js file 