### PR TITLE
Rely on exec extending env by default

### DIFF
--- a/packages/vscode-extension/src/builders/buildAndroid.ts
+++ b/packages/vscode-extension/src/builders/buildAndroid.ts
@@ -108,7 +108,7 @@ export async function buildAndroid(
   const buildProcess = cancelToken.adapt(
     exec("./gradlew", gradleArgs, {
       cwd: androidSourceDir,
-      env: { ...process.env, ...buildOptions.env, JAVA_HOME, ANDROID_HOME },
+      env: { ...buildOptions.env, JAVA_HOME, ANDROID_HOME },
       buffer: false,
     })
   );

--- a/packages/vscode-extension/src/builders/buildIOS.ts
+++ b/packages/vscode-extension/src/builders/buildIOS.ts
@@ -107,7 +107,6 @@ function buildProject(
 
   return exec("xcodebuild", xcodebuildArgs, {
     env: {
-      ...process.env,
       ...getLaunchConfiguration().env,
       RCT_NO_LAUNCH_PACKAGER: "true",
     },

--- a/packages/vscode-extension/src/dependency/DependencyChecker.ts
+++ b/packages/vscode-extension/src/dependency/DependencyChecker.ts
@@ -124,7 +124,7 @@ export class DependencyChecker implements Disposable {
 
   public async checkCocoaPodsInstalled() {
     const installed = await checkIfCLIInstalled("pod --version", {
-      env: { ...process.env, LANG: "en_US.UTF-8" },
+      env: { LANG: "en_US.UTF-8" },
     });
     const errorMessage =
       "CocoaPods was not found. Make sure to [install CocoaPods](https://guides.cocoapods.org/using/getting-started.html).";

--- a/packages/vscode-extension/src/dependency/DependencyInstaller.ts
+++ b/packages/vscode-extension/src/dependency/DependencyInstaller.ts
@@ -70,7 +70,6 @@ export function installIOSDependencies(appRootFolder: string, forceCleanBuild: b
   return command("pod install", {
     cwd: iosDirPath,
     env: {
-      ...process.env,
       ...getLaunchConfiguration().env,
       LANG: "en_US.UTF-8",
     },

--- a/packages/vscode-extension/src/devices/AndroidEmulatorDevice.ts
+++ b/packages/vscode-extension/src/devices/AndroidEmulatorDevice.ts
@@ -117,7 +117,7 @@ export class AndroidEmulatorDevice extends DeviceBase {
         "-grpc-use-token",
         "-no-snapshot-save",
       ],
-      { env: { ...process.env, ANDROID_AVD_HOME: avdDirectory } }
+      { env: { ANDROID_AVD_HOME: avdDirectory } }
     );
     this.emulatorProcess = subprocess;
 
@@ -396,7 +396,7 @@ export async function createEmulator(displayName: string, systemImage: AndroidSy
 const UUID_REGEX = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/;
 async function getAvdIds(avdDirectory: string) {
   const { stdout } = await exec(EMULATOR_BINARY, ["-list-avds"], {
-    env: { ...process.env, ANDROID_AVD_HOME: avdDirectory },
+    env: { ANDROID_AVD_HOME: avdDirectory },
   });
 
   // filters out error messages and empty lines

--- a/packages/vscode-extension/src/project/metro.ts
+++ b/packages/vscode-extension/src/project/metro.ts
@@ -138,7 +138,6 @@ export class Metro implements Disposable {
       metroConfigPath = findCustomMetroConfig(launchConfiguration.metroConfigPath);
     }
     const metroEnv = {
-      ...process.env,
       ...launchConfiguration.env,
       ...(metroConfigPath ? { RN_IDE_METRO_CONFIG_PATH: metroConfigPath } : {}),
       NODE_PATH: path.join(appRootFolder, "node_modules"),


### PR DESCRIPTION
When debugging some weird issues associated with env variables, I noticed that execa by default extends the process env. In most of the cases this is the desirable approach and hence we don't need to handle that ourselves as it only makes the whole flow more polluted with unnecessary options.