### PR TITLE
Don't update shared prefs for expo go

### DIFF
--- a/packages/vscode-extension/src/devices/AndroidEmulatorDevice.ts
+++ b/packages/vscode-extension/src/devices/AndroidEmulatorDevice.ts
@@ -151,6 +151,10 @@ export class AndroidEmulatorDevice extends DeviceBase {
   }
 
   async configureExpoDevMenu(packageName: string) {
+    if (packageName === "host.exp.exponent") {
+      // For expo go we are unable to change this setting as the APK is not debuggable
+      return;
+    }
     // this code disables expo devmenu popup when the app is launched. When dev menu
     // is displayed, it blocks the JS loop and hence react devtools are unable to establish
     // the connection, and hence we never get the app ready event.


### PR DESCRIPTION
We recently added code that'd write to shaed prefs in order to disable dev menu popping up on expo dev client on Android. This apparently doesn't work with expo go, as the go APK installed on the emulator is not debuggable. In this PR we add a check for the bundle name before we write the setting.