### PR TITLE
Fix right click when inspecting

### DIFF
--- a/packages/vscode-extension/src/webview/components/Preview.tsx
+++ b/packages/vscode-extension/src/webview/components/Preview.tsx
@@ -160,6 +160,7 @@ function Preview({ isInspecting, setIsInspecting, zoomLevel, onZoomChanged }: Pr
 
   function onInspectorItemSelected(item: InspectDataStackItem) {
     project.openFileAt(item.source.fileName, item.source.line0Based, item.source.column0Based);
+    setIsInspecting(false);
   }
 
   function sendInspectUnthrottled(
@@ -216,7 +217,6 @@ function Preview({ isInspecting, setIsInspecting, zoomLevel, onZoomChanged }: Pr
 
     if (isInspecting) {
       sendInspect(e, e.button === 2 ? "RightButtonDown" : "Down", true);
-      setIsInspecting(false);
     } else if (inspectFrame) {
       // if element is highlighted, we clear it here and ignore first click (don't send it to device)
       resetInspector();


### PR DESCRIPTION
When inspecting via clicking inspect and then using right click, inspector was dismissed even if we didn't select any option.

|Before|After|
|-|-|
|<video src="https://github.com/software-mansion/react-native-ide/assets/12465392/c8965bd8-c9a9-4694-b607-366307882dc0" />|<video src="https://github.com/software-mansion/react-native-ide/assets/12465392/95e98e51-0ffc-47d0-b63e-8378faf5e924" />|









