### PR TITLE
Clear log counter on start

### DIFF
--- a/packages/vscode-extension/src/webview/views/PreviewView.tsx
+++ b/packages/vscode-extension/src/webview/views/PreviewView.tsx
@@ -36,8 +36,8 @@ function PreviewView() {
   const { devices, finishedInitialLoad } = useDevices();
 
   const selectedDevice = projectState?.selectedDevice;
-
   const devicesNotFound = projectState !== undefined && devices.length === 0;
+  const isStarting = projectState.status === "starting";
 
   const { openModal } = useModal();
 
@@ -57,6 +57,12 @@ function PreviewView() {
       project.removeListener("log", incrementLogCounter);
     };
   }, []);
+
+  useEffect(() => {
+    if (isStarting) {
+      setLogCounter(0);
+    }
+  }, [setLogCounter, isStarting]);
 
   useEffect(() => {
     const disableInspectorOnEscape = (event: KeyboardEvent) => {


### PR DESCRIPTION
When reloading the project, logs were cleared (`Runtime.executionContextsCleared` event handler sends ctrl+J to the console which clears it). However, log counter wasn't cleared.

|Before|After|
|-|-|
|<video src="https://github.com/software-mansion/react-native-ide/assets/12465392/f3127666-1deb-4cae-b40a-2785230327b4" />|<video src="https://github.com/software-mansion/react-native-ide/assets/12465392/d83b2033-770e-4ecb-9ce0-c67b31dca245" />| 

