### PR TITLE
Avoid closing IDE accidentally

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -68,6 +68,12 @@
         "command": "RNIDE.openDevMenu",
         "key": "ctrl+alt+z",
         "mac": "ctrl+cmd+z"
+      },
+      {
+        "command": "RNIDE.closeWithConfirmation",
+        "key": "ctrl+w",
+        "mac": "cmd+w",
+        "when": "RNIDE.isTabPanelFocused"
       }
     ],
     "configuration": {

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -108,6 +108,16 @@ export async function activate(context: ExtensionContext) {
     }
   }
 
+  function closeWithConfirmation() {
+    window
+      .showWarningMessage("Are you sure you want to close the IDE panel?", "Yes", "No")
+      .then((item) => {
+        if (item === "Yes") {
+          commands.executeCommand("RNIDE.closePanel");
+        }
+      });
+  }
+
   context.subscriptions.push(
     window.registerWebviewViewProvider(
       SidePanelViewProvider.viewType,
@@ -119,6 +129,9 @@ export async function activate(context: ExtensionContext) {
   context.subscriptions.push(commands.registerCommand("RNIDE.closePanel", closeIDEPanel));
   context.subscriptions.push(commands.registerCommand("RNIDE.openPanel", showIDEPanel));
   context.subscriptions.push(commands.registerCommand("RNIDE.showPanel", showIDEPanel));
+  context.subscriptions.push(
+    commands.registerCommand("RNIDE.closeWithConfirmation", closeWithConfirmation)
+  );
   context.subscriptions.push(
     commands.registerCommand("RNIDE.diagnose", diagnoseWorkspaceStructure)
   );


### PR DESCRIPTION
## Problem
Currently, there is a chance of accidentally closing the IDE panel and it can be an unpleasant experience
## Solution
Simple confirmation popup to avoid headaches.  The following popup only appears if users click `cmd+w/ctr+w` 
https://github.com/software-mansion/react-native-ide/assets/77052270/70c45f35-9d89-4b99-ad97-9f69e0cbc96e



https://github.com/software-mansion/react-native-ide/issues/387



