### PR TITLE
Add possibility to hide zoom controls

### DIFF
--- a/packages/vscode-extension/src/common/Project.ts
+++ b/packages/vscode-extension/src/common/Project.ts
@@ -10,6 +10,10 @@ export type DeviceSettings = {
   };
 };
 
+export type WindowState = {
+  hoveredEdge: "top" | "bottom" | "left" | "right" | null;
+};
+
 export type ProjectState = {
   status:
     | "starting"
@@ -83,6 +87,7 @@ export interface ProjectEventMap {
   log: { type: string };
   projectStateChanged: ProjectState;
   deviceSettingsChanged: DeviceSettings;
+  windowStateChanged: WindowState;
   navigationChanged: { displayName: string; id: string };
   needsNativeRebuild: void;
 }
@@ -100,6 +105,9 @@ export interface ProjectInterface {
 
   getDeviceSettings(): Promise<DeviceSettings>;
   updateDeviceSettings(deviceSettings: DeviceSettings): Promise<void>;
+
+  getWindowState(): Promise<WindowState>;
+  updateWindowState(newState: Partial<WindowState>): Promise<void>;
 
   reportIssue(): Promise<void>;
 

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -24,6 +24,7 @@ import {
   ProjectInterface,
   ProjectState,
   StartupMessage,
+  WindowState,
   ZoomLevelType,
 } from "../common/Project";
 import { EventEmitter } from "stream";
@@ -37,6 +38,7 @@ import { AndroidEmulatorDevice } from "../devices/AndroidEmulatorDevice";
 const DEVICE_SETTINGS_KEY = "device_settings_v2";
 const LAST_SELECTED_DEVICE_KEY = "last_selected_device";
 const PREVIEW_ZOOM_KEY = "preview_zoom";
+const WINDOW_STATE_KEY = "window_state";
 
 export class Project implements Disposable, MetroDelegate, ProjectInterface {
   public static currentProject: Project | undefined;
@@ -71,6 +73,10 @@ export class Project implements Disposable, MetroDelegate, ProjectInterface {
       isDisabled: true,
     },
   };
+
+  private windowState: WindowState = extensionContext.workspaceState.get(WINDOW_STATE_KEY, {
+    hoveredEdge: null,
+  });
 
   constructor(private readonly deviceManager: DeviceManager) {
     Project.currentProject = this;
@@ -381,6 +387,16 @@ export class Project implements Disposable, MetroDelegate, ProjectInterface {
     extensionContext.workspaceState.update(DEVICE_SETTINGS_KEY, settings);
     await this.deviceSession?.changeDeviceSettings(settings);
     this.eventEmitter.emit("deviceSettingsChanged", this.deviceSettings);
+  }
+
+  public async getWindowState() {
+    return this.windowState;
+  }
+
+  public async updateWindowState(newState: WindowState) {
+    this.windowState = newState;
+    extensionContext.workspaceState.update;
+    this.eventEmitter.emit("windowStateChanged", this.windowState);
   }
 
   private reportStageProgress(stageProgress: number, stage: string) {

--- a/packages/vscode-extension/src/webview/components/Preview.tsx
+++ b/packages/vscode-extension/src/webview/components/Preview.tsx
@@ -118,9 +118,11 @@ function Preview({ isInspecting, setIsInspecting, zoomLevel, onZoomChanged }: Pr
   const wrapperDivRef = useRef<HTMLDivElement>(null);
   const [isPressing, setIsPressing] = useState(false);
   const previewRef = useRef<HTMLImageElement>(null);
+  const [isZoomControlHovered, setIsZoomControlHovered] = useState(false);
+  const [isZoomLevelSelectOpen, setIsZoomLevelSelectOpen] = useState(false);
   const [showPreviewRequested, setShowPreviewRequested] = useState(false);
 
-  const { projectState, project } = useProject();
+  const { projectState, project, windowState } = useProject();
 
   const projectStatus = projectState.status;
 
@@ -301,6 +303,9 @@ function Preview({ isInspecting, setIsInspecting, zoomLevel, onZoomChanged }: Pr
     return sd.name === projectState?.selectedDevice?.name;
   });
 
+  const displayZoomControls =
+    windowState.hoveredEdge === "left" || isZoomLevelSelectOpen || isZoomControlHovered;
+
   const shouldPreventTouchInteraction =
     debugPaused ||
     debugException ||
@@ -436,14 +441,19 @@ function Preview({ isInspecting, setIsInspecting, zoomLevel, onZoomChanged }: Pr
           </Resizable>
         )}
       </div>
+      {displayZoomControls && (
       <div className="button-group-left">
         <ZoomControls
           zoomLevel={zoomLevel}
           onZoomChanged={onZoomChanged}
+          onControlsOpenChange={setIsZoomLevelSelectOpen}
           device={device}
+          onHoverIn={() => setIsZoomControlHovered(true)}
+          onHoverOut={() => setIsZoomControlHovered(false)}
           wrapperDivRef={wrapperDivRef}
         />
       </div>
+      )}
     </>
   );
 }

--- a/packages/vscode-extension/src/webview/components/ZoomControls.tsx
+++ b/packages/vscode-extension/src/webview/components/ZoomControls.tsx
@@ -12,11 +12,23 @@ export const DEVICE_DEFAULT_SCALE = 1 / 3;
 type ZoomControlsProps = {
   zoomLevel: ZoomLevelType;
   onZoomChanged: (zoom: ZoomLevelType) => void;
+  onControlsOpenChange?: (isOpen: boolean) => void;
   device?: DeviceProperties;
   wrapperDivRef?: RefObject<HTMLDivElement>;
+  onHoverIn?: () => void;
+  onHoverOut?: () => void;
 };
 
-const ZoomLevelSelect = ({ zoomLevel, onZoomChanged }: ZoomControlsProps) => {
+type ZoomLevelSelectProps = Pick<
+  ZoomControlsProps,
+  "zoomLevel" | "onZoomChanged" | "onControlsOpenChange"
+>;
+
+const ZoomLevelSelect = ({
+  zoomLevel,
+  onZoomChanged,
+  onControlsOpenChange,
+}: ZoomLevelSelectProps) => {
   const onValueChange = useCallback(
     (e: string) => {
       if (e == "Fit") {
@@ -30,6 +42,7 @@ const ZoomLevelSelect = ({ zoomLevel, onZoomChanged }: ZoomControlsProps) => {
 
   return (
     <Select.Root
+      onOpenChange={onControlsOpenChange}
       onValueChange={onValueChange}
       value={zoomLevel === "Fit" ? "Fit" : zoomLevel.toString()}>
       <Select.Trigger className="zoom-select-trigger" disabled={false}>
@@ -60,7 +73,15 @@ const ZoomLevelSelect = ({ zoomLevel, onZoomChanged }: ZoomControlsProps) => {
   );
 };
 
-function ZoomControls({ zoomLevel, onZoomChanged, device, wrapperDivRef }: ZoomControlsProps) {
+function ZoomControls({
+  zoomLevel,
+  onZoomChanged,
+  device,
+  onControlsOpenChange,
+  onHoverIn,
+  onHoverOut,
+  wrapperDivRef,
+}: ZoomControlsProps) {
   function handleZoom(shouldIncrease: boolean) {
     let currentZoomLevel;
     if (zoomLevel === "Fit") {
@@ -78,7 +99,7 @@ function ZoomControls({ zoomLevel, onZoomChanged, device, wrapperDivRef }: ZoomC
   }
 
   return (
-    <div className="zoom-controls">
+    <div className="zoom-controls" onMouseEnter={onHoverIn} onMouseLeave={onHoverOut}>
       <IconButton
         className="zoom-out-button"
         tooltip={{
@@ -88,7 +109,11 @@ function ZoomControls({ zoomLevel, onZoomChanged, device, wrapperDivRef }: ZoomC
         onClick={() => handleZoom(false)}>
         <span className="codicon codicon-zoom-out" />
       </IconButton>
-      <ZoomLevelSelect zoomLevel={zoomLevel} onZoomChanged={onZoomChanged} />
+      <ZoomLevelSelect
+        zoomLevel={zoomLevel}
+        onZoomChanged={onZoomChanged}
+        onControlsOpenChange={onControlsOpenChange}
+      />
       <IconButton
         className="zoom-in-button"
         tooltip={{


### PR DESCRIPTION
In case of a tight panel width, it’s easy for the simulator to overlap with the zoom controls. This PR adds an option in the settings to toggle the visibility of these controls. For me it's extremally useful with the “Fit” zoom setting.

Before:
<img width="346" alt="image" src="https://github.com/software-mansion/react-native-ide/assets/18529692/316ea29a-f826-4383-b06e-d61758b4334e">

After:
<img width="346" alt="image" src="https://github.com/software-mansion/react-native-ide/assets/18529692/89fbfece-6353-4d35-8bf0-e3c84d933e86">
