### PR TITLE
Add .xcode.env.local to gitignore across all projects

### DIFF
--- a/test-apps/react-native-73/ios/.gitignore
+++ b/test-apps/react-native-73/ios/.gitignore
@@ -1,0 +1,1 @@
+.xcode.env.local

--- a/test-apps/react-native-73/ios/.xcode.env.local
+++ b/test-apps/react-native-73/ios/.xcode.env.local
@@ -1,2 +1,0 @@
-export NODE_BINARY=/opt/homebrew/bin/node
-


### PR DESCRIPTION
Some projects have .gitignore inside ios folder that excludes .xcode.env.local while otehr projects doesn't have it. This PR unifies this setting as we don't want dev's local paths included under version control as they may impact builds on other environments.