### PR TITLE
Improve list of system images when creating new device

### DIFF
--- a/packages/vscode-extension/src/common/DeviceManager.ts
+++ b/packages/vscode-extension/src/common/DeviceManager.ts
@@ -29,6 +29,7 @@ export type AndroidSystemImageInfo = {
   name: string;
   location: string;
   apiLevel: number;
+  available: boolean;
 };
 
 export type IOSDeviceTypeInfo = {
@@ -42,6 +43,7 @@ export type IOSRuntimeInfo = {
   name: string;
   version: string;
   supportedDeviceTypes: IOSDeviceTypeInfo[];
+  available: boolean;
 };
 
 export interface DeviceManagerEventMap {

--- a/packages/vscode-extension/src/utilities/iosRuntimes.ts
+++ b/packages/vscode-extension/src/utilities/iosRuntimes.ts
@@ -18,5 +18,14 @@ export async function getAvailableIosRuntimes(): Promise<IOSRuntimeInfo[]> {
   const result: { runtimes: RuntimeInfo[] } = JSON.parse(
     (await exec("xcrun", ["simctl", "list", "runtimes", "--json"])).stdout
   );
-  return result.runtimes.filter((runtime) => runtime.platform === "iOS" && runtime.isAvailable);
+  return result.runtimes
+    .filter((runtime) => runtime.platform === "iOS")
+    .map((runtime) => ({
+      platform: runtime.platform,
+      identifier: runtime.identifier,
+      name: runtime.name,
+      version: runtime.version,
+      supportedDeviceTypes: runtime.supportedDeviceTypes,
+      available: runtime.isAvailable,
+    }));
 }

--- a/packages/vscode-extension/src/webview/views/CreateDeviceView.tsx
+++ b/packages/vscode-extension/src/webview/views/CreateDeviceView.tsx
@@ -73,10 +73,12 @@ function CreateDeviceView({ onCreate, onCancel }: CreateDeviceViewProps) {
       ? iOSRuntimes.map((runtime) => ({
           value: runtime.identifier,
           label: runtime.name,
+          disabled: !runtime.available,
         }))
       : androidImages.map((systemImage) => ({
           value: systemImage.location,
           label: systemImage.name,
+          disabled: !systemImage.available,
         }));
 
   async function createDevice() {


### PR DESCRIPTION
This PR adds some improvements to system image list that gets displayed in the new device creation flow.

1) We no longer limit number of Android images to 3
2) We still show images that are not available (before we'd hide them which was confusing in some cases as users saw they had some images installed but they couldn't use them in the IDE)
![image](https://github.com/software-mansion/react-native-ide/assets/726445/72247893-3f4b-43ba-bf4e-1a14f3de3d6d)
3) We mark android images with incompatible ABI as not available (we only allow images with the current cpu architecture to run)

Test plan:
1) Go over device creation flow
2) Install x86 android image on M1 mac and see it being listed but disabled.