### PR TITLE
Make clicking progress message more discoverable

### DIFF
--- a/packages/vscode-extension/src/webview/components/PreviewLoader.css
+++ b/packages/vscode-extension/src/webview/components/PreviewLoader.css
@@ -23,6 +23,9 @@
 .preview-loader-message {
   text-wrap: nowrap;
   width: 100%;
+}
+
+.preview-loader-slow-progress {
   text-decoration: underline;
 }
 

--- a/packages/vscode-extension/src/webview/components/PreviewLoader.css
+++ b/packages/vscode-extension/src/webview/components/PreviewLoader.css
@@ -23,6 +23,7 @@
 .preview-loader-message {
   text-wrap: nowrap;
   width: 100%;
+  text-decoration: underline;
 }
 
 .preview-loader-stage-progress {

--- a/packages/vscode-extension/src/webview/components/shared/StartupMessage.tsx
+++ b/packages/vscode-extension/src/webview/components/shared/StartupMessage.tsx
@@ -5,7 +5,7 @@ import { StartupMessage } from "../../../common/Project";
 
 interface StartupMessageProps {
   children: React.ReactNode;
-  className?: string;
+  className: string;
 }
 
 const dots = ["", ".", "..", "..."];


### PR DESCRIPTION
The ability to click the startup message to see more was pretty obscure. Now, if some startup step takes more than 30s, we underline the message so users understand clickability. Most of the time it's not needed, this is meant for situations where RNIDE gets stuck on some step.



https://github.com/software-mansion/react-native-ide/assets/12465392/80ef8bff-9509-46cb-9650-fc8813fe695f

