### PR TITLE
Handle empty shared preferences file when setting options for Android

### DIFF
--- a/packages/vscode-extension/src/devices/AndroidEmulatorDevice.ts
+++ b/packages/vscode-extension/src/devices/AndroidEmulatorDevice.ts
@@ -176,7 +176,7 @@ export class AndroidEmulatorDevice extends DeviceBase {
 
   async configureMetroPort(packageName: string, metroPort: number) {
     // read preferences
-    let prefs: { map: any };
+    let prefs: { map: Object };
     try {
       const { stdout } = await exec(
         ADB_PATH,

--- a/packages/vscode-extension/src/devices/AndroidEmulatorDevice.ts
+++ b/packages/vscode-extension/src/devices/AndroidEmulatorDevice.ts
@@ -176,7 +176,7 @@ export class AndroidEmulatorDevice extends DeviceBase {
 
   async configureMetroPort(packageName: string, metroPort: number) {
     // read preferences
-    let prefs: { map: Object };
+    let prefs: { map: any };
     try {
       const { stdout } = await exec(
         ADB_PATH,

--- a/packages/vscode-extension/src/devices/AndroidEmulatorDevice.ts
+++ b/packages/vscode-extension/src/devices/AndroidEmulatorDevice.ts
@@ -176,7 +176,7 @@ export class AndroidEmulatorDevice extends DeviceBase {
 
   async configureMetroPort(packageName: string, metroPort: number) {
     // read preferences
-    let prefs: any;
+    let prefs: { map: {} };
     try {
       const { stdout } = await exec(
         ADB_PATH,
@@ -192,6 +192,8 @@ export class AndroidEmulatorDevice extends DeviceBase {
         { allowNonZeroExit: true }
       );
       prefs = await xml2js.parseStringPromise(stdout, { explicitArray: true });
+      // test if prefs.map is an object, otherwise we just start from an empty prefs
+      if (typeof prefs.map !== "object") throw new Error("Invalid prefs file format");
     } catch (e) {
       // preferences file does not exists
       prefs = { map: {} };

--- a/packages/vscode-extension/src/devices/AndroidEmulatorDevice.ts
+++ b/packages/vscode-extension/src/devices/AndroidEmulatorDevice.ts
@@ -176,7 +176,7 @@ export class AndroidEmulatorDevice extends DeviceBase {
 
   async configureMetroPort(packageName: string, metroPort: number) {
     // read preferences
-    let prefs: { map: {} };
+    let prefs: { map: any };
     try {
       const { stdout } = await exec(
         ADB_PATH,


### PR DESCRIPTION
This PR fixes an issue we found with some setups. After the app is installed for the first time on Android, it sometimes would get the shared preferences file creates as an empty file. As a result, neither the parser nor the `cat` command would throw but the resulting prefs object would be null. 

This PR adds a check for the structure of prefs objects, such that we can be sure it has the expected structure (containing a `map` field in particular), before we continue with updating the prefs object.

Test:
As I couldn't reproduce this issue on my local environment, the change that I did was to clear up the shared preferences file after the app was already installed, then perform a clean build on Android.