### PR TITLE
Add information about keybindings to dropdown menu. 

### DIFF
--- a/packages/vscode-extension/src/common/Project.ts
+++ b/packages/vscode-extension/src/common/Project.ts
@@ -98,6 +98,7 @@ export interface ProjectInterface {
   selectDevice(deviceInfo: DeviceInfo): Promise<void>;
   updatePreviewZoomLevel(zoom: ZoomLevelType): Promise<void>;
 
+  getCommandsCurrentKeyBinding(commandName: string): Promise<string | undefined>;
   getDeviceSettings(): Promise<DeviceSettings>;
   updateDeviceSettings(deviceSettings: DeviceSettings): Promise<void>;
 

--- a/packages/vscode-extension/src/webview/components/SettingsDropdown.tsx
+++ b/packages/vscode-extension/src/webview/components/SettingsDropdown.tsx
@@ -7,6 +7,7 @@ import ManageDevicesView from "../views/ManageDevicesView";
 import { ProjectInterface } from "../../common/Project";
 import DoctorIcon from "./icons/DoctorIcon";
 import { useWorkspaceConfig } from "../providers/WorkspaceConfigProvider";
+import { KeybindingInfo } from "./shared/KyebindingInfo";
 
 interface SettingsDropdownProps {
   children: React.ReactNode;
@@ -50,7 +51,16 @@ function SettingsDropdown({ project, isDeviceRunning, children, disabled }: Sett
               project.openDevMenu();
             }}>
             <span className="codicon codicon-code" />
-            Open dev menu
+            <div
+              style={{
+                display: "flex",
+                width: "100%",
+                flexDirection: "row",
+                justifyContent: "space-between",
+              }}>
+              Open dev menu
+              <KeybindingInfo commandName="RNIDE.openDevMenu" />
+            </div>
           </DropdownMenu.Item>
 
           <DropdownMenu.Sub>

--- a/packages/vscode-extension/src/webview/components/shared/KeybindingInfo.css
+++ b/packages/vscode-extension/src/webview/components/shared/KeybindingInfo.css
@@ -4,3 +4,15 @@
   display: flex;
   align-items: center;
 }
+
+.symbol {
+  border-radius: 3px;
+  border-style: solid;
+  border-width: 1px;
+  display: inline-block;
+  font-size: 11px;
+  margin: 0 2px;
+  padding: 3px 5px;
+  vertical-align: middle;
+  font-family: -apple-system, BlinkMacSystemFont, sans-serif;
+}

--- a/packages/vscode-extension/src/webview/components/shared/KeybindingInfo.css
+++ b/packages/vscode-extension/src/webview/components/shared/KeybindingInfo.css
@@ -1,0 +1,6 @@
+.keybinding {
+  color: var(--swm-secondary-text);
+  font-size: 10px;
+  display: flex;
+  align-items: center;
+}

--- a/packages/vscode-extension/src/webview/components/shared/KyebindingInfo.tsx
+++ b/packages/vscode-extension/src/webview/components/shared/KyebindingInfo.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { ReactNode, useEffect, useState } from "react";
 import "./KeybindingInfo.css";
 import { useProject } from "../../providers/ProjectProvider";
 
@@ -6,15 +6,54 @@ interface KeybindingInfoProps {
   commandName: string;
 }
 
+interface SymbolProps {
+  children: ReactNode;
+}
+
+const Symbol = ({ children }: SymbolProps) => {
+  return <span className="symbol">{children}</span>;
+};
+
 export const KeybindingInfo = ({ commandName }: KeybindingInfoProps) => {
   const { project } = useProject();
-  const [keybinding, setKeybinding] = useState("");
+  const [keybinding, setKeybinding] = useState<string[]>([]);
+
+  function translateToUnicode(symbol: string) {
+    let icons = {
+      cmd: "\u2318", // ⌘
+      ctrl: "\u2303", // ⌃
+      alt: "\u2325", // ⌥
+      option: "\u2325", // ⌥
+      shift: "\u21E7", // ⇧
+      tab: "\u21E5", // ⇥
+      up: "\u2191", // ↑
+      down: "\u2193", // ↓
+      left: "\u2190", // ←
+      right: "\u2192", // →
+    };
+    return icons[symbol.toLowerCase() as keyof typeof icons] || symbol.toUpperCase();
+  }
 
   useEffect(() => {
     project.getCommandsCurrentKeyBinding(commandName).then((res) => {
-      setKeybinding(res ?? "");
+      if (res) {
+        const result = res?.split(/[+ ]/).map((key) => {
+          key.trim();
+          return translateToUnicode(key);
+        });
+        setKeybinding(result);
+      } else {
+        setKeybinding([]);
+      }
     });
   }, []);
 
-  return <div className="keybinding"> {keybinding}</div>;
+  return (
+    <div className="keybinding">
+      {" "}
+      {keybinding.map((symbol, index) => {
+        return <Symbol key={index}>{symbol}</Symbol>;
+      })}
+    </div>
+  );
 };

--- a/packages/vscode-extension/src/webview/components/shared/KyebindingInfo.tsx
+++ b/packages/vscode-extension/src/webview/components/shared/KyebindingInfo.tsx
@@ -1,0 +1,20 @@
+import { useEffect, useState } from "react";
+import "./KeybindingInfo.css";
+import { useProject } from "../../providers/ProjectProvider";
+
+interface KeybindingInfoProps {
+  commandName: string;
+}
+
+export const KeybindingInfo = ({ commandName }: KeybindingInfoProps) => {
+  const { project } = useProject();
+  const [keybinding, setKeybinding] = useState("");
+
+  useEffect(() => {
+    project.getCommandsCurrentKeyBinding(commandName).then((res) => {
+      setKeybinding(res ?? "");
+    });
+  }, []);
+
+  return <div className="keybinding"> {keybinding}</div>;
+};

--- a/packages/vscode-extension/src/webview/components/shared/KyebindingInfo.tsx
+++ b/packages/vscode-extension/src/webview/components/shared/KyebindingInfo.tsx
@@ -6,33 +6,25 @@ interface KeybindingInfoProps {
   commandName: string;
 }
 
-interface SymbolProps {
-  children: ReactNode;
+function translateToUnicode(symbol: string) {
+  let icons = {
+    cmd: "⌘",
+    ctrl: "⌃",
+    alt: "⌥",
+    option: "⌥",
+    shift: "⇧",
+    tab: "⇥",
+    up: "↑",
+    down: "↓",
+    left: "←",
+    right: "→",
+  };
+  return icons[symbol.toLowerCase() as keyof typeof icons] || symbol.toUpperCase();
 }
-
-const Symbol = ({ children }: SymbolProps) => {
-  return <span className="symbol">{children}</span>;
-};
 
 export const KeybindingInfo = ({ commandName }: KeybindingInfoProps) => {
   const { project } = useProject();
   const [keybinding, setKeybinding] = useState<string[]>([]);
-
-  function translateToUnicode(symbol: string) {
-    let icons = {
-      cmd: "\u2318", // ⌘
-      ctrl: "\u2303", // ⌃
-      alt: "\u2325", // ⌥
-      option: "\u2325", // ⌥
-      shift: "\u21E7", // ⇧
-      tab: "\u21E5", // ⇥
-      up: "\u2191", // ↑
-      down: "\u2193", // ↓
-      left: "\u2190", // ←
-      right: "\u2192", // →
-    };
-    return icons[symbol.toLowerCase() as keyof typeof icons] || symbol.toUpperCase();
-  }
 
   useEffect(() => {
     project.getCommandsCurrentKeyBinding(commandName).then((res) => {
@@ -52,7 +44,11 @@ export const KeybindingInfo = ({ commandName }: KeybindingInfoProps) => {
     <div className="keybinding">
       {" "}
       {keybinding.map((symbol, index) => {
-        return <Symbol key={index}>{symbol}</Symbol>;
+        return (
+          <span key={index} className="symbol">
+            {symbol}
+          </span>
+        );
       })}
     </div>
   );


### PR DESCRIPTION
### Description: 

This PR is addressing a problem with discoverability of a keybinding that allows users to open dev-menu (cmd+shift+z by default). The new UI hopefully, will clear up the confusion users may had, caused by  their experience with expo shortcuts. It also provides a function that allows to check current keybinding for commands contributed by RNIDE, even if user has set custom ones.  

### Potential improvements: 
This functionality could be further improved by adding a listener that would inform the UI about changes in user keybindings (aka. keybindings.json file), but as it seems very unlikely that somebody is going to have a dropdown menu open and at the same time changing keybindings in vscode settings, it does not seem to be a priority right now. 

### Note 
keybinding.json is the only place we should expect keybinding to be changed, according to [this article](https://code.visualstudio.com/docs/getstarted/keybindings)
also alexdima explains here why they do not plan on introducing per workspace keybindings [here](https://github.com/Microsoft/vscode/issues/4504)


### before 
<img width="233" alt="Screenshot 2024-07-03 at 13 55 29" src="https://github.com/software-mansion/react-native-ide/assets/159789821/f9363707-e801-456f-9974-080c195ac7cc">

### after 
<img width="243" alt="Screenshot 2024-07-08 at 15 56 28" src="https://github.com/software-mansion/react-native-ide/assets/159789821/abd9b7ba-8fb7-4049-a213-4ca987697fa9">
