### PR TITLE
Avoid passing PWD entirely to subprocesses when cwd option is set

### DIFF
--- a/packages/vscode-extension/src/utilities/subprocess.ts
+++ b/packages/vscode-extension/src/utilities/subprocess.ts
@@ -4,6 +4,9 @@ import readline from "readline";
 
 export type ChildProcess = ExecaChildProcess<string>;
 
+function updatePWDInArgs<T extends execa.Options>(args: [string, string[]?, T?]): typeof args;
+function updatePWDInArgs<T extends execa.Options>(args: [string, T?]): typeof args;
+
 function updatePWDInArgs<T extends execa.Options>(args: [string, string[]?, T?]) {
   if (args.length > 1) {
     const options = args[args.length - 1] as T;

--- a/packages/vscode-extension/src/utilities/subprocess.ts
+++ b/packages/vscode-extension/src/utilities/subprocess.ts
@@ -47,8 +47,11 @@ export function lineReader(childProcess: ExecaChildProcess<string>, includeStder
   };
 }
 
-type ExecArgs = [string, string[]?, (execa.Options & { allowNonZeroExit?: boolean })?];
-export function exec([name, args, options]: ExecArgs) {
+export function exec(
+  name: string,
+  args?: string[],
+  options?: execa.Options & { allowNonZeroExit?: boolean }
+) {
   const subprocess = execa(name, args, overridePWD(options));
   const allowNonZeroExit = options?.allowNonZeroExit;
   async function printErrorsOnExit() {
@@ -73,7 +76,7 @@ export function exec([name, args, options]: ExecArgs) {
   return subprocess;
 }
 
-export function execSync([name, args, options]: [string, string[]?, execa.SyncOptions?]) {
+export function execSync(name: string, args?: string[], options?: execa.SyncOptions) {
   const result = execa.sync(name, args, overridePWD(options));
   if (result.stderr) {
     Logger.debug("Subprocess", name, args?.join(" "), "produced error output:", result.stderr);
@@ -81,7 +84,7 @@ export function execSync([name, args, options]: [string, string[]?, execa.SyncOp
   return result;
 }
 
-export function command([commandWithArgs, options]: [string, execa.Options?]) {
+export function command(commandWithArgs: string, options?: execa.Options) {
   const subprocess = execa.command(commandWithArgs, overridePWD(options));
   async function printErrorsOnExit() {
     try {

--- a/packages/vscode-extension/src/utilities/subprocess.ts
+++ b/packages/vscode-extension/src/utilities/subprocess.ts
@@ -4,17 +4,19 @@ import readline from "readline";
 
 export type ChildProcess = ExecaChildProcess<string>;
 
-function updatePWDInArgs<T extends execa.Options>(args: [string, string[]?, T?]): typeof args;
-function updatePWDInArgs<T extends execa.Options>(args: [string, T?]): typeof args;
-
-function updatePWDInArgs<T extends execa.Options>(args: [string, string[]?, T?]) {
-  if (args.length > 1) {
-    const options = args[args.length - 1] as T;
-    if (options && options.cwd) {
-      (args[args.length - 1] as T) = { ...options, env: { ...options.env, PWD: "0" } };
-    }
+function overridePWD<T extends execa.Options>(options?: T) {
+  // Some processes rely on PWD environment variable to tell the current working
+  // directory in which cases PWD takes precedence over process.cwd.
+  // By default, execa would copy all process env to the subprocess (which is desired)
+  // including PWD that may point to a different location that the selected cwd (indicated
+  // by options.cwd). Specifically, when VSCode is launched from the launcher (as opposed to
+  // being launched from command line using 'code' command), the PWD is set to "/".
+  // This method overrides PWD to the current cwd option when it's set for the subprocess call
+  // therefore removing the risk of the subprocess using the wrong working directory.
+  if (options?.cwd) {
+    return { ...options, env: { ...options.env, PWD: options.cwd } };
   }
-  return args;
+  return undefined;
 }
 
 /**
@@ -45,37 +47,24 @@ export function lineReader(childProcess: ExecaChildProcess<string>, includeStder
   };
 }
 
-export function exec(
-  ...args: [string, string[]?, (execa.Options & { allowNonZeroExit?: boolean })?]
-) {
-  const subprocess = execa(...updatePWDInArgs(args));
-  const allowNonZeroExit = args[2]?.allowNonZeroExit;
+type ExecArgs = [string, string[]?, (execa.Options & { allowNonZeroExit?: boolean })?];
+export function exec([name, args, options]: ExecArgs) {
+  const subprocess = execa(name, args, overridePWD(options));
+  const allowNonZeroExit = options?.allowNonZeroExit;
   async function printErrorsOnExit() {
     try {
       const result = await subprocess;
       if (result.stderr) {
-        Logger.debug(
-          "Subprocess",
-          args[0],
-          args[1]?.join(" "),
-          "produced error output:",
-          result.stderr
-        );
+        Logger.debug("Subprocess", name, args?.join(" "), "produced error output:", result.stderr);
       }
     } catch (e) {
       // @ts-ignore idk how to deal with error objects in ts
       const { exitCode, signal } = e;
       if (exitCode === undefined && signal !== undefined) {
-        Logger.info("Subprocess", args[0], "was terminated with", signal);
+        Logger.info("Subprocess", name, "was terminated with", signal);
       } else {
         if (!allowNonZeroExit || !exitCode) {
-          Logger.error(
-            "Subprocess",
-            args[0],
-            args[1]?.join(" "),
-            "execution resulted in an error:",
-            e
-          );
+          Logger.error("Subprocess", name, args?.join(" "), "execution resulted in an error:", e);
         }
       }
     }
@@ -84,30 +73,24 @@ export function exec(
   return subprocess;
 }
 
-export function execSync(...args: [string, string[]?, execa.SyncOptions?]) {
-  const result = execa.sync(...updatePWDInArgs(args));
+export function execSync([name, args, options]: [string, string[]?, execa.SyncOptions?]) {
+  const result = execa.sync(name, args, overridePWD(options));
   if (result.stderr) {
-    Logger.debug(
-      "Subprocess",
-      args[0],
-      args[1]?.join(" "),
-      "produced error output:",
-      result.stderr
-    );
+    Logger.debug("Subprocess", name, args?.join(" "), "produced error output:", result.stderr);
   }
   return result;
 }
 
-export function command(...args: [string, execa.Options?]) {
-  const subprocess = execa.command(...updatePWDInArgs(args));
+export function command([commandWithArgs, options]: [string, execa.Options?]) {
+  const subprocess = execa.command(commandWithArgs, overridePWD(options));
   async function printErrorsOnExit() {
     try {
       const result = await subprocess;
       if (result.stderr) {
-        Logger.debug("Command", args[0], "produced error output:", result.stderr);
+        Logger.debug("Command", commandWithArgs, "produced error output:", result.stderr);
       }
     } catch (e) {
-      Logger.error("Command", args[0], "execution resulted in an error:", e);
+      Logger.error("Command", commandWithArgs, "execution resulted in an error:", e);
     }
   }
   printErrorsOnExit(); // don't want to await here not to block the outer method


### PR DESCRIPTION
This fixes an issue when VSCode started from app launcher would populate PWD environment constant which interfers with some tooling.

We've already attempted to fix that in #369 but the fix really only worked when PWD was set as options.

Aparently execa library that we use for subprocess management by default inheritcs process.env (which is what we want). But in that case env.PWD would be provided even despite the fact it wasn't included in env from the options. This got broken along with #378 where we stopped manually passing process.env when launching.

As a consequence, we will now always override PWD with "0" which will result in third-party checks to fail on that variable.

Test plan:
Launch react-conf-app repo with VSCode started from launcher 