### PR TITLE
Fix cmd + A selecting the device image 

### DIFF
--- a/packages/vscode-extension/src/webview/components/Preview.css
+++ b/packages/vscode-extension/src/webview/components/Preview.css
@@ -30,6 +30,7 @@
   height: var(--phone-screen-height);
   top: var(--phone-top);
   left: calc(var(--phone-left) - 7px);
+  user-select: none;
 }
 
 .phone-sized {
@@ -42,6 +43,7 @@
   mask-image: var(--phone-mask-image);
   -webkit-mask-size: cover;
   mask-size: cover;
+  user-select: none;
 }
 
 .phone-screen {
@@ -54,6 +56,7 @@
   mask-image: var(--phone-mask-image);
   -webkit-mask-size: cover;
   mask-size: cover;
+  user-select: none;
 }
 
 .phone-frame {

--- a/packages/vscode-extension/src/webview/hooks/useResizableProps.tsx
+++ b/packages/vscode-extension/src/webview/hooks/useResizableProps.tsx
@@ -63,6 +63,7 @@ export function useResizableProps({
       ...resizableStyle,
       display: phoneHeight === 0 ? "none" : "flex",
       alignItems: "center",
+      userSelect: "none",
     },
     handleStyles: {
       bottomRight: {

--- a/packages/vscode-extension/src/webview/views/View.css
+++ b/packages/vscode-extension/src/webview/views/View.css
@@ -9,7 +9,3 @@
   height: 100%;
   user-select: none;
 }
-
-.panel-view ::selection {
-  background: transparent;
-}

--- a/packages/vscode-extension/src/webview/views/View.css
+++ b/packages/vscode-extension/src/webview/views/View.css
@@ -9,3 +9,7 @@
   height: 100%;
   user-select: none;
 }
+
+.panel-view ::selection {
+  background: transparent;
+}


### PR DESCRIPTION
This PR hides, device selection that happens when user presses cmd + A. 

This change is required because the user-select css property is not inheritable, which is why it does not disable global selection (using ctrl + A or double-click). 
 
Fixes: #434 

