### PR TITLE
Correctly pass options to exec-like functions

### DIFF
--- a/packages/vscode-extension/src/utilities/subprocess.ts
+++ b/packages/vscode-extension/src/utilities/subprocess.ts
@@ -16,7 +16,7 @@ function overridePWD<T extends execa.Options>(options?: T) {
   if (options?.cwd) {
     return { ...options, env: { ...options.env, PWD: options.cwd } };
   }
-  return undefined;
+  return options;
 }
 
 /**


### PR DESCRIPTION
This PR fixes a bug introduced in #432.

The bug caused "options" argument to be removed from subprocesses that did not specify the cwd. 
