### PR TITLE
docs: Add Supporter Licence section banner

### DIFF
--- a/packages/docs/src/components/HomepageButton/styles.module.css
+++ b/packages/docs/src/components/HomepageButton/styles.module.css
@@ -132,6 +132,19 @@ a.homepageButtonLink:hover {
   border: 1px solid var(--swm-landing-button-navy);
 }
 
+.buttonWhiteStyling {
+  background-color: transparent;
+  color: var(--swm-landing-button-navy);
+}
+
+.buttonWhiteStyling svg {
+  stroke: var(--swm-landing-button-navy);
+}
+
+.buttonWhiteStyling:hover {
+  background-color: var(--swm-off-white);
+}
+
 .arrow {
   position: relative;
   display: flex;

--- a/packages/docs/src/components/LicenceBanner/index.tsx
+++ b/packages/docs/src/components/LicenceBanner/index.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import HomepageButton, { ButtonStyling, BorderStyling } from "@site/src/components/HomepageButton";
+import styles from "./styles.module.css";
+
+const LicenceBanner = () => {
+  return (
+    <div className={styles.licenceContainer}>
+      <div className={styles.elipse} />
+      <div className={styles.elipse} />
+      <div className={styles.contentContainer}>
+        <h2>Supporter Licence is now available!</h2>
+        <span>
+          Get access to private Discord channel for feature requests and support and 50% discount on
+          future Individual or Team license.
+        </span>
+      </div>
+      <HomepageButton
+        target="_blank"
+        href="/pricing"
+        backgroundStyling={ButtonStyling.TO_WHITE}
+        borderStyling={BorderStyling.NAVY}
+        title="Get the Licence"
+      />
+    </div>
+  );
+};
+
+export default LicenceBanner;

--- a/packages/docs/src/components/LicenceBanner/styles.module.css
+++ b/packages/docs/src/components/LicenceBanner/styles.module.css
@@ -1,0 +1,59 @@
+.licenceContainer {
+  background-color: #b1dfd0;
+  padding: 2.5rem;
+  display: flex;
+  flex-direction: row;
+  gap: 4.5rem;
+  position: relative;
+  overflow: hidden;
+}
+
+.contentContainer {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  flex: 3;
+  z-index: 3;
+}
+
+.contentContainer span {
+  font-size: 20px;
+}
+
+.licenceContainer a {
+  display: flex;
+  align-items: flex-end;
+  z-index: 3;
+}
+
+@media (max-width: 996px) {
+  .licenceContainer {
+    flex-direction: column;
+    gap: 1.5rem;
+  }
+  .contentContainer span,
+  .contentContainer h2 {
+    text-wrap: balance;
+  }
+}
+
+.elipse {
+  height: 250px;
+  width: 250px;
+  border-radius: 50%;
+  background: linear-gradient(90deg, #ffffff66 35%, #ffffff33 70%, #ffffff00 100%);
+  position: absolute;
+  z-index: 2;
+}
+
+.elipse:nth-of-type(1) {
+  top: -8rem;
+  left: -6rem;
+  rotate: 80deg;
+}
+
+.elipse:nth-of-type(2) {
+  right: -8rem;
+  bottom: -10rem;
+  rotate: 180deg;
+}

--- a/packages/docs/src/pages/index.tsx
+++ b/packages/docs/src/pages/index.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import Layout from "@theme/Layout";
 import Hero from "@site/src/components/Hero/StartScreen";
 import Disclaimer from "@site/src/components/Disclaimer";
+import LicenceBanner from "@site/src/components/LicenceBanner";
 import LearnMoreHero from "@site/src/components/LearnMore/LearnMoreHero";
 import LearnMoreFooter from "@site/src/components/LearnMore/LearnMoreFooter";
 import Installation from "@site/src/components/Sections/Installation";
@@ -24,6 +25,7 @@ export default function Home(): JSX.Element {
         <div className={styles.container}>
           <Hero />
           <Disclaimer />
+          <LicenceBanner />
           {/* <LearnMoreHero /> */}
           {/* <Installation /> */}
           <Overview />


### PR DESCRIPTION
This PR adds Supporter Licence section banner.

<img width="1359" alt="image" src="https://github.com/software-mansion/react-native-ide/assets/59940332/4c0514c6-63a2-441e-8a0c-3c96bb8200ca">
