### PR TITLE
Fix opening a different workspace after device was removed. 

### DIFF
--- a/packages/vscode-extension/src/devices/DeviceManager.ts
+++ b/packages/vscode-extension/src/devices/DeviceManager.ts
@@ -85,12 +85,12 @@ export class DeviceManager implements Disposable, DeviceManagerInterface {
   private async loadDevices(forceReload = false) {
     if (forceReload) {
       // Clear the cache when force reload is requested
-      extensionContext.workspaceState.update(DEVICE_LIST_CACHE_KEY, undefined);
+      extensionContext.globalState.update(DEVICE_LIST_CACHE_KEY, undefined);
     }
     if (!this.loadDevicesPromise || forceReload) {
       this.loadDevicesPromise = this.loadDevicesInternal().then((devices) => {
         this.loadDevicesPromise = undefined;
-        extensionContext.workspaceState.update(DEVICE_LIST_CACHE_KEY, devices);
+        extensionContext.globalState.update(DEVICE_LIST_CACHE_KEY, devices);
         return devices;
       });
     }
@@ -121,7 +121,7 @@ export class DeviceManager implements Disposable, DeviceManagerInterface {
   }
 
   public async listAllDevices() {
-    const devices = extensionContext.workspaceState.get(DEVICE_LIST_CACHE_KEY) as
+    const devices = extensionContext.globalState.get(DEVICE_LIST_CACHE_KEY) as
       | DeviceInfo[]
       | undefined;
     if (devices) {


### PR DESCRIPTION
### Description
In this [commit](https://github.com/software-mansion/react-native-ide/commit/24703d99ed2657fa0996ac987633edec08e7b45c) we introduced a cacheing strategy for listing all devices, because the cache was workspace specific it caused problems when switching workspaces. This PR fixes those issues by opting for globalState, as a caching mechanism. 

#### How to test:
- Open project A and use device A
- Open project B, switch to a different device and remove device A
- Open again project A
- It will now select the first available device.

fixes: #439