### PR TITLE
Extract just preview address from sim-server logs

### DIFF
--- a/packages/vscode-extension/src/devices/preview.ts
+++ b/packages/vscode-extension/src/devices/preview.ts
@@ -33,10 +33,15 @@ export class Preview implements Disposable {
         reject(new Error("Preview server exited without URL"));
       });
 
+      const streamURLRegex = /(http:\/\/[^ ]*stream\.mjpeg)/;
+
       lineReader(subprocess).onLineRead((line) => {
-        if (line.includes("http://")) {
-          Logger.debug(`Preview server ready ${line}`);
-          this.streamURL = line;
+        const match = line.match(streamURLRegex);
+
+        if (match) {
+          Logger.debug(`Preview server ready ${match[1]}`);
+
+          this.streamURL = match[1];
           resolve(this.streamURL);
         }
         Logger.debug("Preview server:", line);


### PR DESCRIPTION
This PR adreses the problem that introduced by a change in sim-server that logs: 
`Stream live on ${adres}` instead of `${adres}` when the preview is ready. 

Additionally a new approach allows us to make sure that the url is the required  stream and frees up the sim-server to log other links in the future. 