### PR TITLE
Fix not disappearing error bar

### DIFF
--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -530,6 +530,7 @@ export class Project implements Disposable, MetroDelegate, ProjectInterface {
 
   // used in callbacks, needs to be an arrow function
   private removeDeviceListener = async (_devices: DeviceInfo) => {
+    this.updateProjectState({ status: "starting" });
     await this.trySelectingInitialDevice();
   };
 

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -529,9 +529,11 @@ export class Project implements Disposable, MetroDelegate, ProjectInterface {
   }
 
   // used in callbacks, needs to be an arrow function
-  private removeDeviceListener = async (_devices: DeviceInfo) => {
-    this.updateProjectState({ status: "starting" });
-    await this.trySelectingInitialDevice();
+  private removeDeviceListener = async (device: DeviceInfo) => {
+    if (this.projectState.selectedDevice?.id === device.id) {
+      this.updateProjectState({ status: "starting" });
+      await this.trySelectingInitialDevice();
+    }
   };
 
   private checkIfNativeChanged = throttle(async () => {


### PR DESCRIPTION
This PR fixes the issue of the error bar persisting even after removing the iOS device. 
After removing the device, the project state is set to "starting" to ensure it doesn't remain in the "buildError" state.
Although the error bar is visible after device removal, it disappears after a few seconds.

Resolving the issue of selecting the removed device ensures that the error bar is hidden completely in this case.

resolves: #466 