### PR TITLE
Fix passing OS to webview

### DIFF
--- a/packages/vscode-extension/src/common/utils.ts
+++ b/packages/vscode-extension/src/common/utils.ts
@@ -1,5 +1,3 @@
-import { Platform } from "../utilities/platform";
-
 export interface UtilsInterface {
   getCommandsCurrentKeyBinding(commandName: string): Promise<string | undefined>;
 
@@ -7,6 +5,4 @@ export interface UtilsInterface {
 
   openFileAt(filePath: string, line0Based: number, column0Based: number): Promise<void>;
   movePanelToNewWindow(): void;
-
-  get Platform(): Platform;
 }

--- a/packages/vscode-extension/src/panels/webviewContentGenerator.ts
+++ b/packages/vscode-extension/src/panels/webviewContentGenerator.ts
@@ -2,6 +2,7 @@ import { ExtensionContext, ExtensionMode, Webview, Uri, extensions } from "vscod
 import { getUri } from "../utilities/getUri";
 import { getNonce } from "../utilities/getNonce";
 import { getDevServerScriptUrl } from "../utilities/common";
+import { Platform } from "../utilities/platform";
 
 const VITE_DEV_HOST = "localhost:2137";
 
@@ -60,6 +61,7 @@ export function generateWebviewContent(
       </head>
       <body>
         <div id="root"></div>
+        <script>window.RNIDE_hostOS = "${Platform.OS}";</script>
         <script type="module" nonce="${nonce}" src="${scriptUri}" />
       </body>
     </html>

--- a/packages/vscode-extension/src/utilities/platform.ts
+++ b/packages/vscode-extension/src/utilities/platform.ts
@@ -1,18 +1,18 @@
-import * as os from "os";
+import os from "os";
 
-type PlatformType = "macos" | "windows";
-
+const OS: "macos" | "windows" = (() => {
+  const platform = os.platform();
+  switch (platform) {
+    case "darwin":
+      return "macos";
+    case "win32":
+      return "windows";
+    default:
+      throw new Error("Unsupported platform");
+  }
+})();
 export const Platform = {
-  OS: (() => {
-    const platform = os.platform() as "darwin" | "win32";
-    switch (platform) {
-      case "darwin":
-        return "macos" as PlatformType;
-      case "win32":
-        return "windows" as PlatformType;
-    }
-  })(),
-
+  OS,
   select: <R, T>(obj: { macos: R; windows: T }) => {
     return obj[Platform.OS];
   },

--- a/packages/vscode-extension/src/utilities/utils.ts
+++ b/packages/vscode-extension/src/utilities/utils.ts
@@ -76,8 +76,4 @@ export class Utils implements UtilsInterface {
   public movePanelToNewWindow() {
     commands.executeCommand("workbench.action.moveEditorToNewWindow");
   }
-
-  public get Platform() {
-    return Platform;
-  }
 }

--- a/packages/vscode-extension/src/webview/providers/DevicesProvider.tsx
+++ b/packages/vscode-extension/src/webview/providers/DevicesProvider.tsx
@@ -13,7 +13,7 @@ import {
   DeviceManagerInterface,
   IOSRuntimeInfo,
 } from "../../common/DeviceManager";
-import { useUtils } from "../providers/UtilsProvider";
+import { Platform } from "../providers/UtilsProvider";
 
 const DeviceManager = makeProxy<DeviceManagerInterface>("DeviceManager");
 
@@ -36,7 +36,6 @@ const DevicesContext = createContext<DevicesContextProps>({
 });
 
 export default function DevicesProvider({ children }: PropsWithChildren) {
-  const { Platform } = useUtils();
   const [devices, setDevices] = useState<DeviceInfo[]>([]);
   const [androidImages, setAndroidImages] = useState<AndroidSystemImageInfo[]>([]);
   const [iOSRuntimes, setIOSRuntimes] = useState<IOSRuntimeInfo[]>([]);
@@ -47,9 +46,10 @@ export default function DevicesProvider({ children }: PropsWithChildren) {
       await Promise.all([
         DeviceManager.listAllDevices().then(setDevices),
         DeviceManager.listInstalledAndroidImages().then(setAndroidImages),
-        ...(Platform.OS == "macos"
-          ? [DeviceManager.listInstalledIOSRuntimes().then(setIOSRuntimes)]
-          : []),
+        ...Platform.select({
+          macos: [DeviceManager.listInstalledIOSRuntimes().then(setIOSRuntimes)],
+          windows: [],
+        }),
       ]);
     } finally {
       setFinishedInitialLoad(true);

--- a/packages/vscode-extension/src/webview/providers/UtilsProvider.tsx
+++ b/packages/vscode-extension/src/webview/providers/UtilsProvider.tsx
@@ -3,6 +3,20 @@ import { makeProxy } from "../utilities/rpc";
 import { Utils } from "../../utilities/utils";
 import { UtilsInterface } from "../../common/utils";
 
+declare global {
+  interface Window {
+    // set in generateWebviewContent()
+    RNIDE_hostOS: "macos" | "windows";
+  }
+}
+
+export const Platform = {
+  OS: window.RNIDE_hostOS,
+  select: <R, T>(obj: { macos: R; windows: T }) => {
+    return obj[Platform.OS];
+  },
+};
+
 const utils = makeProxy<Utils>("Utils");
 
 const UtilsContext = createContext<UtilsInterface>(utils);

--- a/packages/vscode-extension/src/webview/views/CreateDeviceView.tsx
+++ b/packages/vscode-extension/src/webview/views/CreateDeviceView.tsx
@@ -11,7 +11,7 @@ import {
 } from "../utilities/consts";
 import { DevicePlatform } from "../../common/DeviceManager";
 import { useDependencies } from "../providers/DependenciesProvider";
-import { useUtils } from "../providers/UtilsProvider";
+import { Platform } from "../providers/UtilsProvider";
 
 interface CreateDeviceViewProps {
   onCreate: () => void;
@@ -25,7 +25,6 @@ function assertPlatform(platform: string): asserts platform is "ios" | "android"
 }
 
 function useSupportedDevices() {
-  const { Platform } = useUtils();
   const { androidEmulatorError, iosSimulatorError } = useDependencies();
 
   function buildSelections(item: DeviceProperties, platform: DevicePlatform) {
@@ -63,7 +62,6 @@ function useSupportedDevices() {
 }
 
 function CreateDeviceView({ onCreate, onCancel }: CreateDeviceViewProps) {
-  const { Platform } = useUtils();
   const [deviceName, setDeviceName] = useState<string | undefined>(undefined);
   const [devicePlatform, setDevicePlatform] = useState<"ios" | "android" | undefined>(undefined);
   const [selectedSystemName, selectSystemName] = useState<string | undefined>(undefined);
@@ -99,7 +97,7 @@ function CreateDeviceView({ onCreate, onCancel }: CreateDeviceViewProps) {
 
     setLoading(true);
     try {
-      if (devicePlatform === "ios" && Platform.OS == "macos") {
+      if (devicePlatform === "ios" && Platform.OS === "macos") {
         const runtime = iOSRuntimes.find(({ identifier }) => identifier === selectedSystemName);
         if (!runtime) {
           return;

--- a/packages/vscode-extension/src/webview/views/DevicesNotFoundView.tsx
+++ b/packages/vscode-extension/src/webview/views/DevicesNotFoundView.tsx
@@ -10,7 +10,7 @@ import { AndroidSupportedDevices, iOSSupportedDevices } from "../utilities/const
 import { IOSDeviceTypeInfo, IOSRuntimeInfo } from "../../common/DeviceManager";
 import { useDependencies } from "../providers/DependenciesProvider";
 import { vscode } from "../utilities/vscode";
-import { useUtils } from "../providers/UtilsProvider";
+import { Platform } from "../providers/UtilsProvider";
 
 const firstIosDeviceName = iOSSupportedDevices[0].name;
 const firstAndroidDeviceName = AndroidSupportedDevices[0].name;
@@ -64,7 +64,6 @@ function findNewestIosRuntime(runtimes: IOSRuntimeInfo[]) {
 }
 
 function DevicesNotFoundView() {
-  const { Platform } = useUtils();
   const { openModal, closeModal } = useModal();
   const { iOSRuntimes, androidImages, deviceManager } = useDevices();
   const [isIOSCreating, withIosCreating] = useLoadingState();
@@ -124,7 +123,7 @@ function DevicesNotFoundView() {
         You can add a new device using the quick action below.
       </p>
       <div className="devices-not-found-button-group">
-        {Platform.OS == "macos" && (
+        {Platform.OS === "macos" && (
           <Button
             type="ternary"
             className="devices-not-found-quick-action"


### PR DESCRIPTION
Originally, we passed it as object with functions. We only transform top level functions as proxies. Additionally, to not require it to be async (or to wait until we resolve it) we pass it as global and reimplement functionality on the webview side.