### PR TITLE
Extract debugger code to own class

### DIFF
--- a/packages/vscode-extension/src/debugging/DebugSession.ts
+++ b/packages/vscode-extension/src/debugging/DebugSession.ts
@@ -1,0 +1,79 @@
+import {
+  debug,
+  DebugSessionCustomEvent,
+  Disposable,
+  DebugSession as VscDebugSession,
+} from "vscode";
+
+export type DebugSessionDelegate = {
+  onConsoleLog(event: DebugSessionCustomEvent): void;
+  onDebuggerPaused(event: DebugSessionCustomEvent): void;
+  onDebuggerResumed(event: DebugSessionCustomEvent): void;
+};
+
+export class DebugSession implements Disposable {
+  private _session: VscDebugSession | undefined;
+  private debugEventsListener: Disposable;
+
+  constructor(private debuggerUrl: string, private delegate: DebugSessionDelegate) {
+    this.debugEventsListener = debug.onDidReceiveDebugSessionCustomEvent((event) => {
+      switch (event.event) {
+        case "RNIDE_consoleLog":
+          this.delegate.onConsoleLog(event);
+          break;
+        case "RNIDE_paused":
+          this.delegate.onDebuggerPaused(event);
+          break;
+        case "RNIDE_continued":
+          this.delegate.onDebuggerResumed(event);
+          break;
+        default:
+          // ignore other events
+          break;
+      }
+    });
+  }
+
+  public dispose() {
+    this.session && debug.stopDebugging(this.session);
+    this.debugEventsListener.dispose();
+  }
+
+  public async start() {
+    const debugStarted = await debug.startDebugging(
+      undefined,
+      {
+        type: "com.swmansion.react-native-ide",
+        name: "React Native IDE Debugger",
+        request: "attach",
+        websocketAddress: this.debuggerUrl,
+      },
+      {
+        suppressDebugStatusbar: true,
+        suppressDebugView: true,
+        suppressDebugToolbar: true,
+        suppressSaveBeforeStart: true,
+      }
+    );
+    if (debugStarted) {
+      this._session = debug.activeDebugSession!;
+      return true;
+    }
+    return false;
+  }
+
+  public resumeDebugger() {
+    this.session.customRequest("continue");
+  }
+
+  public stepOverDebugger() {
+    this.session.customRequest("next");
+  }
+
+  private get session() {
+    if (!this._session) {
+      throw new Error("Debugger not started");
+    }
+    return this._session;
+  }
+}

--- a/packages/vscode-extension/src/debugging/DebugSession.ts
+++ b/packages/vscode-extension/src/debugging/DebugSession.ts
@@ -12,7 +12,7 @@ export type DebugSessionDelegate = {
 };
 
 export class DebugSession implements Disposable {
-  private _session: VscDebugSession | undefined;
+  private vscSession: VscDebugSession | undefined;
   private debugEventsListener: Disposable;
 
   constructor(private debuggerUrl: string, private delegate: DebugSessionDelegate) {
@@ -56,7 +56,7 @@ export class DebugSession implements Disposable {
       }
     );
     if (debugStarted) {
-      this._session = debug.activeDebugSession!;
+      this.vscSession = debug.activeDebugSession!;
       return true;
     }
     return false;
@@ -71,9 +71,9 @@ export class DebugSession implements Disposable {
   }
 
   private get session() {
-    if (!this._session) {
+    if (!this.vscSession) {
       throw new Error("Debugger not started");
     }
-    return this._session;
+    return this.vscSession;
   }
 }

--- a/packages/vscode-extension/src/project/devtools.ts
+++ b/packages/vscode-extension/src/project/devtools.ts
@@ -78,18 +78,6 @@ export class Devtools implements Disposable {
     this.socket?.send(JSON.stringify({ event, payload }));
   }
 
-  public rpc(event: string, payload: any, responseEvent: string, callback: (payload: any) => void) {
-    const listener = (message: string, data: any) => {
-      if (message === responseEvent) {
-        callback(data);
-        this.removeListener(listener);
-      }
-    };
-
-    this.addListener(listener);
-    this.send(event, payload);
-  }
-
   public addListener(listener: (event: string, payload: any) => void) {
     this.listeners.add(listener);
   }

--- a/packages/vscode-extension/src/project/metro.ts
+++ b/packages/vscode-extension/src/project/metro.ts
@@ -214,10 +214,12 @@ export class Metro implements Disposable {
     await fetch(`http://localhost:${this._port}/reload`);
   }
 
-  public async getDebuggerURL(timeoutMs: number) {
+  public async getDebuggerURL() {
+    const WAIT_FOR_DEBUGGER_TIMEOUT_MS = 15_000;
+
     const startTime = Date.now();
     let websocketAddress: string | undefined;
-    while (!websocketAddress && Date.now() - startTime < timeoutMs) {
+    while (!websocketAddress && Date.now() - startTime < WAIT_FOR_DEBUGGER_TIMEOUT_MS) {
       websocketAddress = await this.fetchDebuggerURL();
       await new Promise((res) => setTimeout(res, 1000));
     }


### PR DESCRIPTION
This is the first PR from series of six that try to extract as much code as possible from Project.
It extracts code related to controlling debugger to `DebugSession` class and does some minor improvements to `Project`'s code.

The end goal is to create simpler interfaces and allow for fine-grained controls of reloading.

The idea I had in mind was to move build and metro/devtools lifecycle into DeviceSession and allow to control lifecycle of both device-independent components (such as metro) and devices.
State that originally lived in Project was moved in other places or updated by creating callbacks and passing Project as delegate to those places.

This effort isn't finished but is ready enough to implement parts of original goal.

<details><summary>After-refactor API notes</summary>
<p>

```

// Procedure to start and run project on device
selectDevice
if(device) {
  startDevtools
  startMetro

  bootDevice | buildApp – simultaneous
  installApp
  launchApp
}

// Project's callbacks to update its internal state based on events happening in DeviceSession
Delegate {
  onStateChange()
  onStateProgress()
  onAppEvent()
  onBundleError()
  onIncrementalBundleError()
  onBuildError()
}

// Structure of DeviceSession after refactor. It should own lifecycle of Metro, Devtools, build, and selected device.
DeviceSession {
  constructor(deviceInfo, eventDelegate)
  get device()
  async start()
  async changeDevice(deviceInfo): Device // partially disposes state via disposeDevice() and selects another device
  async perform(type)
  dispose()

  private:
    disposeDevice()
}

// Supported `deviceSession.perform(type)` actions.
type ReloadAction =
  | "rebuild"
  | "reboot"
  | "reinstall"
  | "restartProcess"
  | "reloadJs"
  | "hotReload";
```

</p>
</details> 