### PR TITLE
Move app event handling to device session

### DIFF
--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -10,7 +10,6 @@ import { AndroidEmulatorDevice } from "../devices/AndroidEmulatorDevice";
 import { getLaunchConfiguration } from "../utilities/launchConfiguration";
 import { DebugSession, DebugSessionDelegate } from "../debugging/DebugSession";
 
-type ProgressCallback = (startupMessage: string) => void;
 type PreviewReadyCallback = (previewURL: string) => void;
 
 export type AppEvent = {
@@ -22,6 +21,7 @@ export type AppEvent = {
 
 export type EventDelegate = {
   onAppEvent<E extends keyof AppEvent, P = AppEvent[E]>(event: E, payload: P): void;
+  onStateChange(state: StartupMessage): void;
 };
 export class DeviceSession implements Disposable {
   private inspectCallID = 7621;
@@ -60,7 +60,7 @@ export class DeviceSession implements Disposable {
     this.device?.dispose();
   }
 
-  private async launch(progressCallback: ProgressCallback) {
+  private async launch() {
     if (!this.buildResult) {
       throw new Error("Expecting build to be ready");
     }
@@ -77,40 +77,35 @@ export class DeviceSession implements Disposable {
         })
       : Promise.resolve();
 
-    progressCallback(StartupMessage.Launching);
+    this.eventDelegate.onStateChange(StartupMessage.Launching);
     await this.device.launchApp(this.buildResult, this.metro.port, this.devtools.port);
 
     Logger.debug("Will wait for app ready and for preview");
-    progressCallback(StartupMessage.WaitingForAppToLoad);
+    this.eventDelegate.onStateChange(StartupMessage.WaitingForAppToLoad);
     await Promise.all([waitForAppReady, this.device.startPreview()]);
     Logger.debug("App and preview ready, moving on...");
-
-    progressCallback(StartupMessage.AttachingDebugger);
+    this.eventDelegate.onStateChange(StartupMessage.AttachingDebugger);
     await this.startDebugger();
   }
 
-  public async restart(progressCallback: ProgressCallback) {
-    return this.launch(progressCallback);
+  public async restart() {
+    return this.launch();
   }
 
-  public async start(
-    deviceSettings: DeviceSettings,
-    previewReadyCallback: PreviewReadyCallback,
-    progressCallback: ProgressCallback
-  ) {
-    progressCallback(StartupMessage.BootingDevice);
+  public async start(deviceSettings: DeviceSettings, previewReadyCallback: PreviewReadyCallback) {
+    this.eventDelegate.onStateChange(StartupMessage.BootingDevice);
     await this.device.bootDevice();
     await this.device.changeSettings(deviceSettings);
-    progressCallback(StartupMessage.Building);
+    this.eventDelegate.onStateChange(StartupMessage.Building);
     this.buildResult = await this.disposableBuild.build;
-    progressCallback(StartupMessage.Installing);
+    this.eventDelegate.onStateChange(StartupMessage.Installing);
     await this.device.installApp(this.buildResult, false);
 
     this.device.startPreview().then(() => {
       previewReadyCallback(this.device.previewURL!);
     });
 
-    await this.launch(progressCallback);
+    await this.launch();
   }
 
   private async startDebugger() {

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -1,7 +1,7 @@
 import { Disposable, commands, workspace, window, DebugSessionCustomEvent } from "vscode";
 import { Metro, MetroDelegate } from "./metro";
 import { Devtools } from "./devtools";
-import { DeviceSession } from "./deviceSession";
+import { AppEvent, DeviceSession, EventDelegate } from "./deviceSession";
 import { Logger } from "../Logger";
 import { BuildManager, didFingerprintChange } from "../builders/BuildManager";
 import { DeviceAlreadyUsedError, DeviceManager } from "../devices/DeviceManager";
@@ -31,7 +31,9 @@ const DEVICE_SETTINGS_KEY = "device_settings_v2";
 const LAST_SELECTED_DEVICE_KEY = "last_selected_device";
 const PREVIEW_ZOOM_KEY = "preview_zoom";
 
-export class Project implements Disposable, MetroDelegate, DebugSessionDelegate, ProjectInterface {
+export class Project
+  implements Disposable, MetroDelegate, EventDelegate, DebugSessionDelegate, ProjectInterface
+{
   public static currentProject: Project | undefined;
 
   private metro: Metro;
@@ -80,6 +82,32 @@ export class Project implements Disposable, MetroDelegate, DebugSessionDelegate,
       this.checkIfNativeChanged();
     });
   }
+  //#region App events
+  onAppEvent<E extends keyof AppEvent, P = AppEvent[E]>(event: E, payload: P): void {
+    switch (event) {
+      case "appReady":
+        Logger.debug("App ready");
+        if (this.reloadingMetro) {
+          this.reloadingMetro = false;
+          this.updateProjectState({ status: "running" });
+        }
+        break;
+      case "navigationChanged":
+        this.eventEmitter.emit("navigationChanged", payload);
+        break;
+      case "fastRefreshStarted":
+        this.updateProjectState({ status: "refreshing" });
+        break;
+      case "fastRefreshComplete":
+        const ignoredEvents = ["starting", "incrementalBundleError", "runtimeError"];
+        if (ignoredEvents.includes(this.projectState.status)) {
+          return;
+        }
+        this.updateProjectState({ status: "running" });
+        break;
+    }
+  }
+  //#endregion
 
   //#region Debugger events
   onConsoleLog(event: DebugSessionCustomEvent) {
@@ -247,32 +275,6 @@ export class Project implements Disposable, MetroDelegate, DebugSessionDelegate,
       oldDevtools.dispose();
       oldMetro.dispose();
     }
-    this.devtools.addListener((event, payload) => {
-      switch (event) {
-        case "RNIDE_appReady":
-          Logger.debug("App ready");
-          if (this.reloadingMetro) {
-            this.reloadingMetro = false;
-            this.updateProjectState({ status: "running" });
-          }
-          break;
-        case "RNIDE_navigationChanged":
-          this.eventEmitter.emit("navigationChanged", {
-            displayName: payload.displayName,
-            id: payload.id,
-          });
-          break;
-        case "RNIDE_fastRefreshStarted":
-          this.updateProjectState({ status: "refreshing" });
-          break;
-        case "RNIDE_fastRefreshComplete":
-          if (this.projectState.status === "starting") return;
-          if (this.projectState.status === "incrementalBundleError") return;
-          if (this.projectState.status === "runtimeError") return;
-          this.updateProjectState({ status: "running" });
-          break;
-      }
-    });
 
     Logger.debug("Installing Node Modules");
     const installNodeModules = this.installNodeModules();
@@ -498,7 +500,7 @@ export class Project implements Disposable, MetroDelegate, DebugSessionDelegate,
       }
 
       Logger.debug("Metro & devtools ready");
-      newDeviceSession = new DeviceSession(device, this.devtools, this.metro, build, this);
+      newDeviceSession = new DeviceSession(device, this.devtools, this.metro, build, this, this);
       this.deviceSession = newDeviceSession;
 
       await newDeviceSession.start(

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -82,6 +82,13 @@ export class Project
       this.checkIfNativeChanged();
     });
   }
+
+  //#region Build progress
+  onStateChange(state: StartupMessage): void {
+    this.updateProjectStateForDevice(this.projectState.selectedDevice!, { startupMessage: state });
+  }
+  //#endregion
+
   //#region App events
   onAppEvent<E extends keyof AppEvent, P = AppEvent[E]>(event: E, payload: P): void {
     switch (event) {
@@ -249,9 +256,7 @@ export class Project
     try {
       // we first check if the device session hasn't changed in the meantime
       if (deviceSession === this.deviceSession) {
-        await this.deviceSession?.restart((startupMessage) =>
-          this.updateProjectStateForDevice(deviceInfo, { startupMessage })
-        );
+        await this.deviceSession?.restart();
         this.updateProjectStateForDevice(deviceInfo, {
           status: "running",
         });
@@ -434,6 +439,7 @@ export class Project
     Logger.debug("Node Modules installed");
   }
 
+  //#region Select device
   private async selectDeviceOnly(deviceInfo: DeviceInfo) {
     let device: IosSimulatorDevice | AndroidEmulatorDevice | undefined;
     try {
@@ -503,13 +509,9 @@ export class Project
       newDeviceSession = new DeviceSession(device, this.devtools, this.metro, build, this, this);
       this.deviceSession = newDeviceSession;
 
-      await newDeviceSession.start(
-        this.deviceSettings,
-        (previewURL) => {
-          this.updateProjectStateForDevice(deviceInfo, { previewURL });
-        },
-        (startupMessage) => this.updateProjectStateForDevice(deviceInfo, { startupMessage })
-      );
+      await newDeviceSession.start(this.deviceSettings, (previewURL) => {
+        this.updateProjectStateForDevice(deviceInfo, { previewURL });
+      });
       Logger.debug("Device session started");
 
       this.updateProjectStateForDevice(deviceInfo, {
@@ -525,6 +527,7 @@ export class Project
       }
     }
   }
+  //#endregion
 
   // used in callbacks, needs to be an arrow function
   private removeDeviceListener = async (device: DeviceInfo) => {

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -131,10 +131,8 @@ export class Project implements Disposable, MetroDelegate, DebugSessionDelegate,
       const lastDeviceId = extensionContext.workspaceState.get<string | undefined>(
         LAST_SELECTED_DEVICE_KEY
       );
-      let device = devices.find((item) => item.id === lastDeviceId);
-      if (!device && devices.length > 0) {
-        device = devices[0];
-      }
+      const device = devices.find(({ id }) => id === lastDeviceId) ?? devices.at(0);
+
       if (device) {
         this.selectDevice(device);
         return true;

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -432,7 +432,7 @@ export class Project implements Disposable, MetroDelegate, DebugSessionDelegate,
     Logger.debug("Node Modules installed");
   }
 
-  public async selectDevice(deviceInfo: DeviceInfo, forceCleanBuild = false) {
+  private async selectDeviceOnly(deviceInfo: DeviceInfo) {
     let device: IosSimulatorDevice | AndroidEmulatorDevice | undefined;
     try {
       device = await this.deviceManager.acquireDevice(deviceInfo);
@@ -447,17 +447,24 @@ export class Project implements Disposable, MetroDelegate, DebugSessionDelegate,
       }
     }
 
+    if (device) {
+      Logger.log("Device selected", deviceInfo.name);
+      extensionContext.workspaceState.update(LAST_SELECTED_DEVICE_KEY, deviceInfo.id);
+      return device;
+    }
+    return undefined;
+  }
+
+  public async selectDevice(deviceInfo: DeviceInfo, forceCleanBuild = false) {
+    const device = await this.selectDeviceOnly(deviceInfo);
     if (!device) {
       return;
     }
 
-    Logger.log("Device selected", deviceInfo.name);
-    extensionContext.workspaceState.update(LAST_SELECTED_DEVICE_KEY, deviceInfo.id);
-
     this.reloadingMetro = false;
-    const prevSession = this.deviceSession;
+
+    this.deviceSession?.dispose();
     this.deviceSession = undefined;
-    prevSession?.dispose();
 
     this.updateProjectState({
       selectedDevice: deviceInfo,


### PR DESCRIPTION
⚠️ Depends on https://github.com/software-mansion/react-native-ide/pull/472.

Second PR in refactoring effort, see https://github.com/software-mansion/react-native-ide/pull/472 for overall notes.

Extracts events coming from app to `DeviceSession` in order to move devtools there in the future. Also extract device selection step to its own function in order to cut code in future refactorings.