### PR TITLE
Remove reloadingMetro state from project

### DIFF
--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -21,7 +21,6 @@ type PerformAction =
   | "hotReload";
 
 export type AppEvent = {
-  appReady: undefined;
   navigationChanged: { displayName: string; id: string };
   fastRefreshStarted: undefined;
   fastRefreshComplete: undefined;
@@ -47,7 +46,7 @@ export class DeviceSession implements Disposable {
     this.devtools.addListener((event, payload) => {
       switch (event) {
         case "RNIDE_appReady":
-          this.eventDelegate.onAppEvent("appReady", undefined);
+          Logger.debug("App ready");
           break;
         case "RNIDE_navigationChanged":
           this.eventDelegate.onAppEvent("navigationChanged", payload);

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -12,6 +12,14 @@ import { DebugSession, DebugSessionDelegate } from "../debugging/DebugSession";
 
 type PreviewReadyCallback = (previewURL: string) => void;
 
+type PerformAction =
+  | "rebuild"
+  | "reboot"
+  | "reinstall"
+  | "restartProcess"
+  | "reloadJs"
+  | "hotReload";
+
 export type AppEvent = {
   appReady: undefined;
   navigationChanged: { displayName: string; id: string };
@@ -58,6 +66,19 @@ export class DeviceSession implements Disposable {
     this.debugSession?.dispose();
     this.disposableBuild?.dispose();
     this.device?.dispose();
+  }
+
+  public async perform(type: PerformAction) {
+    switch (type) {
+      case "hotReload":
+        if (this.devtools.hasConnectedClient) {
+          await this.metro.reload();
+          return true;
+        }
+        return false;
+      default:
+        throw new Error("Not implemented " + type);
+    }
   }
 
   private async launch() {

--- a/packages/vscode-extension/src/project/metro.ts
+++ b/packages/vscode-extension/src/project/metro.ts
@@ -211,7 +211,18 @@ export class Metro implements Disposable {
   }
 
   public async reload() {
+    const appReady = new Promise<void>((resolve) => {
+      const waitForAppReady = (event: string) => {
+        if (event === "RNIDE_appReady") {
+          this.devtools.removeListener(waitForAppReady);
+          resolve();
+        }
+      };
+      this.devtools.addListener(waitForAppReady);
+    });
+
     await fetch(`http://localhost:${this._port}/reload`);
+    await appReady;
   }
 
   public async getDebuggerURL() {


### PR DESCRIPTION
⚠️ Depends on https://github.com/software-mansion/react-native-ide/pull/473.

Third PR in refactoring effort, see https://github.com/software-mansion/react-native-ide/pull/472 for overall notes.

- Changes metro.reload() to wait until app is ready. This allows for removal of `reloadingMetro` state in `Project`.
- Adds initial implementation of `DeviceSession.perform(type)`.