### PR TITLE
Implement restartProcess reload option

### DIFF
--- a/packages/vscode-extension/src/devices/DeviceBase.ts
+++ b/packages/vscode-extension/src/devices/DeviceBase.ts
@@ -43,10 +43,6 @@ export abstract class DeviceBase implements Disposable {
     this.preview?.dispose();
   }
 
-  get previewURL(): string | undefined {
-    return this.preview?.streamURL;
-  }
-
   public sendTouch(xRatio: number, yRatio: number, type: "Up" | "Move" | "Down") {
     this.preview?.sendTouch(xRatio, yRatio, type);
   }

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -82,6 +82,32 @@ export class Project
       this.checkIfNativeChanged();
     });
   }
+  //#region App events
+  onAppEvent<E extends keyof AppEvent, P = AppEvent[E]>(event: E, payload: P): void {
+    switch (event) {
+      case "appReady":
+        Logger.debug("App ready");
+        if (this.reloadingMetro) {
+          this.reloadingMetro = false;
+          this.updateProjectState({ status: "running" });
+        }
+        break;
+      case "navigationChanged":
+        this.eventEmitter.emit("navigationChanged", payload);
+        break;
+      case "fastRefreshStarted":
+        this.updateProjectState({ status: "refreshing" });
+        break;
+      case "fastRefreshComplete":
+        const ignoredEvents = ["starting", "incrementalBundleError", "runtimeError"];
+        if (ignoredEvents.includes(this.projectState.status)) {
+          return;
+        }
+        this.updateProjectState({ status: "running" });
+        break;
+    }
+  }
+  //#endregion
 
   //#region Build progress
   onStateChange(state: StartupMessage): void {

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -87,6 +87,10 @@ export class Project
   onStateChange(state: StartupMessage): void {
     this.updateProjectStateForDevice(this.projectState.selectedDevice!, { startupMessage: state });
   }
+
+  onPreviewReady(url: string): void {
+    this.updateProjectStateForDevice(this.projectState.selectedDevice!, { previewURL: url });
+  }
   //#endregion
 
   //#region App events
@@ -501,9 +505,7 @@ export class Project
       newDeviceSession = new DeviceSession(device, this.devtools, this.metro, build, this, this);
       this.deviceSession = newDeviceSession;
 
-      await newDeviceSession.start(this.deviceSettings, (previewURL) => {
-        this.updateProjectStateForDevice(deviceInfo, { previewURL });
-      });
+      await newDeviceSession.start(this.deviceSettings);
       Logger.debug("Device session started");
 
       this.updateProjectStateForDevice(deviceInfo, {

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -82,32 +82,6 @@ export class Project
       this.checkIfNativeChanged();
     });
   }
-  //#region App events
-  onAppEvent<E extends keyof AppEvent, P = AppEvent[E]>(event: E, payload: P): void {
-    switch (event) {
-      case "appReady":
-        Logger.debug("App ready");
-        if (this.reloadingMetro) {
-          this.reloadingMetro = false;
-          this.updateProjectState({ status: "running" });
-        }
-        break;
-      case "navigationChanged":
-        this.eventEmitter.emit("navigationChanged", payload);
-        break;
-      case "fastRefreshStarted":
-        this.updateProjectState({ status: "refreshing" });
-        break;
-      case "fastRefreshComplete":
-        const ignoredEvents = ["starting", "incrementalBundleError", "runtimeError"];
-        if (ignoredEvents.includes(this.projectState.status)) {
-          return;
-        }
-        this.updateProjectState({ status: "running" });
-        break;
-    }
-  }
-  //#endregion
 
   //#region Build progress
   onStateChange(state: StartupMessage): void {


### PR DESCRIPTION
⚠️ Depends on https://github.com/software-mansion/react-native-ide/pull/474.

Fourth PR in refactoring effort, see https://github.com/software-mansion/react-native-ide/pull/472 for overall notes.

- Adds `onPreviewReady` callback to `Project`.
- Adds `DeviceSession.perform("restartProcess")`