### PR TITLE
Implement reinstallApp reload option

### DIFF
--- a/packages/vscode-extension/src/devices/AndroidEmulatorDevice.ts
+++ b/packages/vscode-extension/src/devices/AndroidEmulatorDevice.ts
@@ -41,7 +41,7 @@ export class AndroidEmulatorDevice extends DeviceBase {
   private emulatorProcess: ChildProcess | undefined;
   private serial: string | undefined;
 
-  constructor(private readonly avdId: string, private readonly _deviceInfo: DeviceInfo) {
+  constructor(private readonly avdId: string, private readonly info: DeviceInfo) {
     super();
   }
 
@@ -50,7 +50,7 @@ export class AndroidEmulatorDevice extends DeviceBase {
   }
 
   get deviceInfo(): DeviceInfo {
-    return this._deviceInfo;
+    return this.info;
   }
 
   get lockFilePath(): string {

--- a/packages/vscode-extension/src/devices/AndroidEmulatorDevice.ts
+++ b/packages/vscode-extension/src/devices/AndroidEmulatorDevice.ts
@@ -41,12 +41,16 @@ export class AndroidEmulatorDevice extends DeviceBase {
   private emulatorProcess: ChildProcess | undefined;
   private serial: string | undefined;
 
-  constructor(private readonly avdId: string) {
+  constructor(private readonly avdId: string, private readonly _deviceInfo: DeviceInfo) {
     super();
   }
 
   public get platform(): DevicePlatform {
     return DevicePlatform.Android;
+  }
+
+  get deviceInfo(): DeviceInfo {
+    return this._deviceInfo;
   }
 
   get lockFilePath(): string {

--- a/packages/vscode-extension/src/devices/DeviceBase.ts
+++ b/packages/vscode-extension/src/devices/DeviceBase.ts
@@ -2,7 +2,7 @@ import { Disposable } from "vscode";
 import { Preview } from "./preview";
 import { BuildResult } from "../builders/BuildManager";
 import { AppPermissionType, DeviceSettings } from "../common/Project";
-import { DevicePlatform } from "../common/DeviceManager";
+import { DeviceInfo, DevicePlatform } from "../common/DeviceManager";
 import { tryAcquiringLock } from "../utilities/common";
 
 import fs from "fs";
@@ -21,6 +21,7 @@ export abstract class DeviceBase implements Disposable {
   abstract launchApp(build: BuildResult, metroPort: number, devtoolsPort: number): Promise<void>;
   abstract makePreview(): Preview;
   abstract get platform(): DevicePlatform;
+  abstract get deviceInfo(): DeviceInfo;
   abstract resetAppPermissions(
     appPermission: AppPermissionType,
     buildResult: BuildResult

--- a/packages/vscode-extension/src/devices/DeviceManager.ts
+++ b/packages/vscode-extension/src/devices/DeviceManager.ts
@@ -62,7 +62,7 @@ export class DeviceManager implements Disposable, DeviceManagerInterface {
       if (!simulatorInfo || simulatorInfo.platform !== DevicePlatform.IOS) {
         throw new Error(`Simulator ${deviceInfo.id} not found`);
       }
-      const device = new IosSimulatorDevice(simulatorInfo.UDID);
+      const device = new IosSimulatorDevice(simulatorInfo.UDID, simulatorInfo);
       if (await device.acquire()) {
         return device;
       } else {
@@ -74,7 +74,7 @@ export class DeviceManager implements Disposable, DeviceManagerInterface {
       if (!emulatorInfo || emulatorInfo.platform !== DevicePlatform.Android) {
         throw new Error(`Emulator ${deviceInfo.id} not found`);
       }
-      const device = new AndroidEmulatorDevice(emulatorInfo.avdId);
+      const device = new AndroidEmulatorDevice(emulatorInfo.avdId, emulatorInfo);
       if (await device.acquire()) {
         return device;
       } else {

--- a/packages/vscode-extension/src/devices/IosSimulatorDevice.ts
+++ b/packages/vscode-extension/src/devices/IosSimulatorDevice.ts
@@ -4,7 +4,7 @@ import { Preview } from "./preview";
 import { Logger } from "../Logger";
 import { exec } from "../utilities/subprocess";
 import { getAvailableIosRuntimes } from "../utilities/iosRuntimes";
-import { IOSDeviceInfo, IOSRuntimeInfo, DevicePlatform } from "../common/DeviceManager";
+import { IOSDeviceInfo, IOSRuntimeInfo, DevicePlatform, DeviceInfo } from "../common/DeviceManager";
 import { BuildResult, IOSBuildResult } from "../builders/BuildManager";
 import path from "path";
 import fs from "fs";
@@ -46,12 +46,16 @@ type PrivacyServiceName =
   | "siri";
 
 export class IosSimulatorDevice extends DeviceBase {
-  constructor(private readonly deviceUDID: string) {
+  constructor(private readonly deviceUDID: string, private readonly _deviceInfo: DeviceInfo) {
     super();
   }
 
   public get platform(): DevicePlatform {
     return DevicePlatform.IOS;
+  }
+
+  public get deviceInfo() {
+    return this._deviceInfo;
   }
 
   get lockFilePath(): string {

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -123,10 +123,6 @@ export class DeviceSession implements Disposable {
     return this.device.installApp(this.buildResult, reinstall);
   }
 
-  public async restart() {
-    await this.perform("restartProcess");
-  }
-
   public async start(deviceSettings: DeviceSettings) {
     this.eventDelegate.onStateChange(StartupMessage.BootingDevice);
     await this.device.bootDevice();

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -34,17 +34,18 @@ export type EventDelegate = {
   onBuildSuccess(): void;
   onPreviewReady(url: string): void;
 };
+
 export class DeviceSession implements Disposable {
   private inspectCallID = 7621;
-  private _buildResult: BuildResult | undefined;
+  private maybeBuildResult: BuildResult | undefined;
   private debugSession: DebugSession | undefined;
   private disposableBuild: DisposableBuild<BuildResult> | undefined;
 
   private get buildResult() {
-    if (!this._buildResult) {
+    if (!this.maybeBuildResult) {
       throw new Error("Expecting build to be ready");
     }
-    return this._buildResult;
+    return this.maybeBuildResult;
   }
 
   constructor(
@@ -139,7 +140,7 @@ export class DeviceSession implements Disposable {
         this.eventDelegate.onBuildProgress(stageProgress);
       }, 100),
     });
-    this._buildResult = await this.disposableBuild.build;
+    this.maybeBuildResult = await this.disposableBuild.build;
   }
 
   private async installApp({ reinstall }: { reinstall: boolean }) {
@@ -178,8 +179,8 @@ export class DeviceSession implements Disposable {
   }
 
   public resetAppPermissions(permissionType: AppPermissionType) {
-    if (this._buildResult) {
-      return this.device.resetAppPermissions(permissionType, this._buildResult);
+    if (this.maybeBuildResult) {
+      return this.device.resetAppPermissions(permissionType, this.maybeBuildResult);
     }
     return false;
   }

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -82,6 +82,32 @@ export class Project
       this.checkIfNativeChanged();
     });
   }
+  //#region App events
+  onAppEvent<E extends keyof AppEvent, P = AppEvent[E]>(event: E, payload: P): void {
+    switch (event) {
+      case "appReady":
+        Logger.debug("App ready");
+        if (this.reloadingMetro) {
+          this.reloadingMetro = false;
+          this.updateProjectState({ status: "running" });
+        }
+        break;
+      case "navigationChanged":
+        this.eventEmitter.emit("navigationChanged", payload);
+        break;
+      case "fastRefreshStarted":
+        this.updateProjectState({ status: "refreshing" });
+        break;
+      case "fastRefreshComplete":
+        const ignoredEvents = ["starting", "incrementalBundleError", "runtimeError"];
+        if (ignoredEvents.includes(this.projectState.status)) {
+          return;
+        }
+        this.updateProjectState({ status: "running" });
+        break;
+    }
+  }
+  //#endregion
 
   //#region Build progress
   onStateChange(state: StartupMessage): void {

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -84,6 +84,15 @@ export class Project
   }
 
   //#region Build progress
+  onBuildProgress(stageProgress: number): void {
+    this.reportStageProgress(stageProgress, StartupMessage.Building);
+  }
+
+  onBuildSuccess(): void {
+    // reset fingerprint change flag when build finishes successfully
+    this.detectedFingerprintChange = false;
+  }
+
   onStateChange(state: StartupMessage): void {
     this.updateProjectStateForDevice(this.projectState.selectedDevice!, { startupMessage: state });
   }
@@ -486,22 +495,19 @@ export class Project
       });
       // wait for metro/devtools to start before we continue
       await Promise.all([this.metro.ready(), this.devtools.ready()]);
-      const build = this.buildManager.startBuild(deviceInfo, {
-        clean: forceCleanBuild,
-        progressListener: throttle((stageProgress: number) => {
-          this.reportStageProgress(stageProgress, StartupMessage.Building);
-        }, 100),
-        onSuccess: () => {
-          // reset fingerprint change flag when build finishes successfully
-          this.detectedFingerprintChange = false;
-        },
-      });
 
       Logger.debug("Metro & devtools ready");
-      newDeviceSession = new DeviceSession(device, this.devtools, this.metro, build, this, this);
+      newDeviceSession = new DeviceSession(
+        device,
+        this.devtools,
+        this.metro,
+        this.buildManager,
+        this,
+        this
+      );
       this.deviceSession = newDeviceSession;
 
-      await newDeviceSession.start(this.deviceSettings);
+      await newDeviceSession.start(this.deviceSettings, { cleanBuild: forceCleanBuild });
       Logger.debug("Device session started");
 
       this.updateProjectStateForDevice(deviceInfo, {

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -211,7 +211,7 @@ export class Project
     this.fileWatcher.dispose();
   }
 
-  public async reloadMetro() {
+  private async reloadMetro() {
     if (await this.deviceSession?.perform("hotReload")) {
       this.updateProjectState({ status: "running" });
     }
@@ -253,7 +253,7 @@ export class Project
     try {
       // we first check if the device session hasn't changed in the meantime
       if (deviceSession === this.deviceSession) {
-        await this.deviceSession?.restart();
+        await this.deviceSession?.perform("restartProcess");
         this.updateProjectStateForDevice(deviceInfo, {
           status: "running",
         });

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -486,20 +486,16 @@ export class Project
       });
       // wait for metro/devtools to start before we continue
       await Promise.all([this.metro.ready(), this.devtools.ready()]);
-      const build = this.buildManager.startBuild(
-        deviceInfo,
-        forceCleanBuild,
-        throttle((stageProgress: number) => {
+      const build = this.buildManager.startBuild(deviceInfo, {
+        clean: forceCleanBuild,
+        progressListener: throttle((stageProgress: number) => {
           this.reportStageProgress(stageProgress, StartupMessage.Building);
-        }, 100)
-      );
-
-      // reset fingerprint change flag when build finishes successfully
-      if (this.detectedFingerprintChange) {
-        build.build.then(() => {
+        }, 100),
+        onSuccess: () => {
+          // reset fingerprint change flag when build finishes successfully
           this.detectedFingerprintChange = false;
-        });
-      }
+        },
+      });
 
       Logger.debug("Metro & devtools ready");
       newDeviceSession = new DeviceSession(device, this.devtools, this.metro, build, this, this);

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -82,32 +82,6 @@ export class Project
       this.checkIfNativeChanged();
     });
   }
-  //#region App events
-  onAppEvent<E extends keyof AppEvent, P = AppEvent[E]>(event: E, payload: P): void {
-    switch (event) {
-      case "appReady":
-        Logger.debug("App ready");
-        if (this.reloadingMetro) {
-          this.reloadingMetro = false;
-          this.updateProjectState({ status: "running" });
-        }
-        break;
-      case "navigationChanged":
-        this.eventEmitter.emit("navigationChanged", payload);
-        break;
-      case "fastRefreshStarted":
-        this.updateProjectState({ status: "refreshing" });
-        break;
-      case "fastRefreshComplete":
-        const ignoredEvents = ["starting", "incrementalBundleError", "runtimeError"];
-        if (ignoredEvents.includes(this.projectState.status)) {
-          return;
-        }
-        this.updateProjectState({ status: "running" });
-        break;
-    }
-  }
-  //#endregion
 
   //#region Build progress
   onStateChange(state: StartupMessage): void {


### PR DESCRIPTION
⚠️ Depends on https://github.com/software-mansion/react-native-ide/pull/475.

Fifth PR in refactoring effort, see https://github.com/software-mansion/react-native-ide/pull/472 for overall notes.

- Adds `DeviceSession.perform("reinstallApp")`.
- Adds device info to device instances.
- Remove `DeviceSession.restart()` and replace uses with `DeviceSession.perform("restartProcess")`.