### PR TITLE
Move buildManager into device session

### DIFF
--- a/packages/vscode-extension/src/devices/DeviceManager.ts
+++ b/packages/vscode-extension/src/devices/DeviceManager.ts
@@ -24,7 +24,6 @@ import {
   AndroidSystemImageInfo,
 } from "../common/DeviceManager";
 import { EventEmitter } from "stream";
-import { Disposable } from "vscode";
 import { Logger } from "../Logger";
 import { extensionContext } from "../utilities/extensionContext";
 import { Platform } from "../utilities/platform";
@@ -32,10 +31,8 @@ import { Platform } from "../utilities/platform";
 const DEVICE_LIST_CACHE_KEY = "device_list_cache";
 
 export class DeviceAlreadyUsedError extends Error {}
-export class DeviceManager implements Disposable, DeviceManagerInterface {
+export class DeviceManager implements DeviceManagerInterface {
   private eventEmitter = new EventEmitter();
-
-  public dispose() {}
 
   public async addListener<K extends keyof DeviceManagerEventMap>(
     eventType: K,

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -10,6 +10,7 @@ import { AndroidEmulatorDevice } from "../devices/AndroidEmulatorDevice";
 import { getLaunchConfiguration } from "../utilities/launchConfiguration";
 import { DebugSession, DebugSessionDelegate } from "../debugging/DebugSession";
 import { throttle } from "../utilities/throttle";
+import { DependencyManager } from "../dependency/DependencyManager";
 
 type PerformAction =
   | "rebuild"
@@ -40,6 +41,7 @@ export class DeviceSession implements Disposable {
   private maybeBuildResult: BuildResult | undefined;
   private debugSession: DebugSession | undefined;
   private disposableBuild: DisposableBuild<BuildResult> | undefined;
+  private buildManager: BuildManager;
 
   private get buildResult() {
     if (!this.maybeBuildResult) {
@@ -52,10 +54,11 @@ export class DeviceSession implements Disposable {
     private readonly device: DeviceBase,
     private readonly devtools: Devtools,
     private readonly metro: Metro,
-    private readonly buildManager: BuildManager,
+    readonly dependencyManager: DependencyManager,
     private readonly debugEventDelegate: DebugSessionDelegate,
     private readonly eventDelegate: EventDelegate
   ) {
+    this.buildManager = new BuildManager(dependencyManager);
     this.devtools.addListener((event, payload) => {
       switch (event) {
         case "RNIDE_appReady":
@@ -252,5 +255,9 @@ export class DeviceSession implements Disposable {
 
   public async changeDeviceSettings(settings: DeviceSettings) {
     await this.device.changeSettings(settings);
+  }
+
+  public focusBuildOutput() {
+    this.buildManager.focusBuildOutput();
   }
 }

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -151,12 +151,21 @@ export class DeviceSession implements Disposable {
     return this.device.installApp(this.buildResult, reinstall);
   }
 
+  private async waitForMetroReady() {
+    this.eventDelegate.onStateChange(StartupMessage.StartingPackager);
+    // wait for metro/devtools to start before we continue
+    await Promise.all([this.metro.ready(), this.devtools.ready()]);
+    Logger.debug("Metro & devtools ready");
+  }
+
   public async start(deviceSettings: DeviceSettings, { cleanBuild }: StartOptions) {
+    await this.waitForMetroReady();
     // TODO(jgonet): Build and boot simultaneously, with predictable state change updates
     await this.bootDevice(deviceSettings);
     await this.buildApp({ clean: cleanBuild });
     await this.installApp({ reinstall: false });
     await this.launchApp();
+    Logger.debug("Device session started");
   }
 
   private async startDebugger() {

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -103,17 +103,7 @@ export class DeviceSession implements Disposable {
 
   private async launchApp() {
     const shouldWaitForAppLaunch = getLaunchConfiguration().preview?.waitForAppLaunch !== false;
-    const waitForAppReady = shouldWaitForAppLaunch
-      ? new Promise<void>((resolve) => {
-          const listener = (event: string) => {
-            if (event === "RNIDE_appReady") {
-              this.devtools.removeListener(listener);
-              resolve();
-            }
-          };
-          this.devtools.addListener(listener);
-        })
-      : Promise.resolve();
+    const waitForAppReady = shouldWaitForAppLaunch ? this.devtools.appReady() : Promise.resolve();
 
     this.eventDelegate.onStateChange(StartupMessage.Launching);
     await this.device.launchApp(this.buildResult, this.metro.port, this.devtools.port);

--- a/packages/vscode-extension/src/project/devtools.ts
+++ b/packages/vscode-extension/src/project/devtools.ts
@@ -25,6 +25,18 @@ export class Devtools implements Disposable {
     await this.startPromise;
   }
 
+  public async appReady() {
+    return new Promise<void>((resolve) => {
+      const listener = (event: string) => {
+        if (event === "RNIDE_appReady") {
+          this.removeListener(listener);
+          resolve();
+        }
+      };
+      this.addListener(listener);
+    });
+  }
+
   public async start() {
     if (this.startPromise) {
       throw new Error("Devtools already started");

--- a/packages/vscode-extension/src/project/metro.ts
+++ b/packages/vscode-extension/src/project/metro.ts
@@ -211,8 +211,9 @@ export class Metro implements Disposable {
   }
 
   public async reload() {
+    const appReady = this.devtools.appReady();
     await fetch(`http://localhost:${this._port}/reload`);
-    await this.devtools.appReady();
+    await appReady;
   }
 
   public async getDebuggerURL() {

--- a/packages/vscode-extension/src/project/metro.ts
+++ b/packages/vscode-extension/src/project/metro.ts
@@ -211,18 +211,8 @@ export class Metro implements Disposable {
   }
 
   public async reload() {
-    const appReady = new Promise<void>((resolve) => {
-      const waitForAppReady = (event: string) => {
-        if (event === "RNIDE_appReady") {
-          this.devtools.removeListener(waitForAppReady);
-          resolve();
-        }
-      };
-      this.devtools.addListener(waitForAppReady);
-    });
-
     await fetch(`http://localhost:${this._port}/reload`);
-    await appReady;
+    await this.devtools.appReady();
   }
 
   public async getDebuggerURL() {

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -239,17 +239,13 @@ export class Project
 
     if (forceCleanBuild) {
       await this.start(true, true);
-      await this.selectDevice(deviceInfo, true);
-      return;
+      return await this.selectDevice(deviceInfo, true);
     } else if (this.detectedFingerprintChange) {
-      await this.selectDevice(deviceInfo, false);
-      return;
+      return await this.selectDevice(deviceInfo, false);
     }
 
-    // if we have an active devtools session, we try hot reloading
-    if (onlyReloadJSWhenPossible && this.devtools.hasConnectedClient) {
-      await this.reloadMetro();
-      return;
+    if (onlyReloadJSWhenPossible) {
+      return await this.reloadMetro();
     }
 
     // otherwise we try to restart the device session

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -3,7 +3,7 @@ import { Metro, MetroDelegate } from "./metro";
 import { Devtools } from "./devtools";
 import { AppEvent, DeviceSession, EventDelegate } from "./deviceSession";
 import { Logger } from "../Logger";
-import { BuildManager, didFingerprintChange } from "../builders/BuildManager";
+import { didFingerprintChange } from "../builders/BuildManager";
 import { DeviceAlreadyUsedError, DeviceManager } from "../devices/DeviceManager";
 import { DeviceInfo } from "../common/DeviceManager";
 import {
@@ -38,7 +38,6 @@ export class Project
 
   private metro: Metro;
   private devtools = new Devtools();
-  private buildManager: BuildManager;
   private eventEmitter = new EventEmitter();
 
   private detectedFingerprintChange: boolean;
@@ -72,7 +71,6 @@ export class Project
   ) {
     Project.currentProject = this;
     this.metro = new Metro(this.devtools, this);
-    this.buildManager = new BuildManager(dependencyManager);
     this.start(false, false);
     this.trySelectingInitialDevice();
     this.deviceManager.addListener("deviceRemoved", this.removeDeviceListener);
@@ -368,10 +366,7 @@ export class Project
   }
 
   public async focusBuildOutput() {
-    if (!this.projectState.selectedDevice) {
-      return;
-    }
-    this.buildManager.focusBuildOutput();
+    this.deviceSession?.focusBuildOutput();
   }
 
   public async focusExtensionLogsOutput() {
@@ -501,7 +496,7 @@ export class Project
         device,
         this.devtools,
         this.metro,
-        this.buildManager,
+        this.dependencyManager,
         this,
         this
       );

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -94,10 +94,6 @@ export class Project
   onStateChange(state: StartupMessage): void {
     this.updateProjectStateForDevice(this.projectState.selectedDevice!, { startupMessage: state });
   }
-
-  onPreviewReady(url: string): void {
-    this.updateProjectStateForDevice(this.projectState.selectedDevice!, { previewURL: url });
-  }
   //#endregion
 
   //#region App events
@@ -494,8 +490,13 @@ export class Project
       );
       this.deviceSession = newDeviceSession;
 
-      await newDeviceSession.start(this.deviceSettings, { cleanBuild: forceCleanBuild });
-      this.updateProjectStateForDevice(deviceInfo, { status: "running" });
+      const previewURL = await newDeviceSession.start(this.deviceSettings, {
+        cleanBuild: forceCleanBuild,
+      });
+      this.updateProjectStateForDevice(this.projectState.selectedDevice!, {
+        previewURL,
+        status: "running",
+      });
     } catch (e) {
       Logger.error("Couldn't start device session", e);
 

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -470,6 +470,7 @@ export class Project
     if (!device) {
       return;
     }
+    Logger.debug("Selected device is ready");
 
     this.deviceSession?.dispose();
     this.deviceSession = undefined;
@@ -482,16 +483,7 @@ export class Project
     });
 
     let newDeviceSession;
-
     try {
-      Logger.debug("Selected device is ready");
-      this.updateProjectStateForDevice(deviceInfo, {
-        startupMessage: StartupMessage.StartingPackager,
-      });
-      // wait for metro/devtools to start before we continue
-      await Promise.all([this.metro.ready(), this.devtools.ready()]);
-
-      Logger.debug("Metro & devtools ready");
       newDeviceSession = new DeviceSession(
         device,
         this.devtools,
@@ -503,11 +495,7 @@ export class Project
       this.deviceSession = newDeviceSession;
 
       await newDeviceSession.start(this.deviceSettings, { cleanBuild: forceCleanBuild });
-      Logger.debug("Device session started");
-
-      this.updateProjectStateForDevice(deviceInfo, {
-        status: "running",
-      });
+      this.updateProjectStateForDevice(deviceInfo, { status: "running" });
     } catch (e) {
       Logger.error("Couldn't start device session", e);
 


### PR DESCRIPTION
⚠️ Depends on https://github.com/software-mansion/react-native-ide/pull/476.

Sixth PR in refactoring effort, see https://github.com/software-mansion/react-native-ide/pull/472 for overall notes.

This change was mostly focused on moving `BuildManager` into `DeviceSession` but I also did a lot of small improvements in project's and device session's code.