### PR TITLE
Add multitouch support

### DIFF
--- a/packages/vscode-extension/src/common/Project.ts
+++ b/packages/vscode-extension/src/common/Project.ts
@@ -114,6 +114,13 @@ export interface ProjectInterface {
   resetAppPermissions(permissionType: AppPermissionType): Promise<void>;
 
   dispatchTouch(xRatio: number, yRatio: number, type: "Up" | "Move" | "Down"): Promise<void>;
+  dispatchMultiTouch(
+    xRatio: number,
+    yRatio: number,
+    xAnchorRatio: number,
+    yAnchorRatio: number,
+    type: "Up" | "Move" | "Down"
+  ): Promise<void>;
   dispatchKeyPress(keyCode: number, direction: "Up" | "Down"): Promise<void>;
   dispatchPaste(text: string): Promise<void>;
   inspectElementAt(

--- a/packages/vscode-extension/src/devices/DeviceBase.ts
+++ b/packages/vscode-extension/src/devices/DeviceBase.ts
@@ -51,6 +51,16 @@ export abstract class DeviceBase implements Disposable {
     this.preview?.sendTouch(xRatio, yRatio, type);
   }
 
+  public sendMultiTouch(
+    xRatio: number,
+    yRatio: number,
+    xAnchorRatio: number,
+    yAnchorRatio: number,
+    type: "Up" | "Move" | "Down"
+  ) {
+    this.preview?.sendMultiTouch(xRatio, yRatio, xAnchorRatio, yAnchorRatio, type);
+  }
+
   public sendKey(keyCode: number, direction: "Up" | "Down") {
     this.preview?.sendKey(keyCode, direction);
   }

--- a/packages/vscode-extension/src/devices/preview.ts
+++ b/packages/vscode-extension/src/devices/preview.ts
@@ -54,6 +54,18 @@ export class Preview implements Disposable {
     this.subprocess?.stdin?.write(`touch${type} ${xRatio} ${yRatio}\n`);
   }
 
+  public sendMultiTouch(
+    xRatio: number,
+    yRatio: number,
+    xAnchorRatio: number,
+    yAnchorRatio: number,
+    type: "Up" | "Move" | "Down"
+  ) {
+    // this.subprocess?.stdin?.write(
+    //   `multitouch${type} ${xRatio} ${yRatio} ${xAnchorRatio} ${yAnchorRatio}\n` // TODO set proper multitouch simserver command
+    // );
+  }
+
   public sendKey(keyCode: number, direction: "Up" | "Down") {
     this.subprocess?.stdin?.write(`key${direction} ${keyCode}\n`);
   }

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -136,6 +136,16 @@ export class DeviceSession implements Disposable {
     this.device.sendTouch(xRatio, yRatio, type);
   }
 
+  public sendMultiTouch(
+    xRatio: number,
+    yRatio: number,
+    xAnchorRatio: number,
+    yAnchorRatio: number,
+    type: "Up" | "Move" | "Down"
+  ) {
+    this.device.sendMultiTouch(xRatio, yRatio, xAnchorRatio, yAnchorRatio, type);
+  }
+
   public sendKey(keyCode: number, direction: "Up" | "Down") {
     this.device.sendKey(keyCode, direction);
   }

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -322,6 +322,16 @@ export class Project implements Disposable, MetroDelegate, ProjectInterface {
     this.deviceSession?.sendTouch(xRatio, yRatio, type);
   }
 
+  public async dispatchMultiTouch(
+    xRatio: number,
+    yRatio: number,
+    xAnchorRatio: number,
+    yAnchorRatio: number,
+    type: "Up" | "Move" | "Down"
+  ) {
+    this.deviceSession?.sendMultiTouch(xRatio, yRatio, xAnchorRatio, yAnchorRatio, type);
+  }
+
   public async dispatchKeyPress(keyCode: number, direction: "Up" | "Down") {
     this.deviceSession?.sendKey(keyCode, direction);
   }

--- a/packages/vscode-extension/src/webview/components/Preview.tsx
+++ b/packages/vscode-extension/src/webview/components/Preview.tsx
@@ -250,12 +250,8 @@ function Preview({ isInspecting, setIsInspecting, zoomLevel, onZoomChanged }: Pr
   function onMouseMove(e: MouseEvent<HTMLDivElement>) {
     e.preventDefault();
     if (isMultiTouching) {
-      if (isPanning) {
-        moveAnchorPoint(e);
-      }
-      if (isPressing) {
-        sendMultiTouch(e, "Move");
-      }
+      isPanning && moveAnchorPoint(e);
+      isPressing && sendMultiTouch(e, "Move");
       setMirroredTouchPoint(getMirroredTouchPosition(anchorPoint));
     } else if (isPressing) {
       sendTouch(e, "Move");

--- a/packages/vscode-extension/src/webview/components/Preview.tsx
+++ b/packages/vscode-extension/src/webview/components/Preview.tsx
@@ -401,6 +401,25 @@ function Preview({ isInspecting, setIsInspecting, zoomLevel, onZoomChanged }: Pr
     device: device!,
   });
 
+  const TouchPointMarker: React.FC<TouchPoint> = ({ x, y }) => {
+    const styles: React.CSSProperties = {
+      position: "absolute",
+      top: `${y * 100}%`,
+      left: `${x * 100}%`,
+      width: "33px",
+      height: "33px",
+      backgroundColor: "rgba(175, 175, 175, 0.75)",
+      borderRadius: "50%",
+      borderColor: "rgba(135, 135, 135, 0.6)",
+      borderWidth: "1px",
+      borderStyle: "solid",
+      transform: "translate(-50%, -50%)",
+      boxShadow: isPressing ? "none" : "2px 2px 6px 1px rgba(0, 0, 0, 0.2)",
+      display: isMultiTouchVisible ? "block" : "none",
+    };
+    return <div style={styles} />;
+  };
+
   return (
     <>
       <div
@@ -420,6 +439,9 @@ function Preview({ isInspecting, setIsInspecting, zoomLevel, onZoomChanged }: Pr
                   }}
                   className="phone-screen"
                 />
+
+                <TouchPointMarker x={touchPoint.x} y={touchPoint.y} />
+                <TouchPointMarker x={mirroredTouchPoint.x} y={mirroredTouchPoint.y} />
 
                 {inspectFrame && (
                   <div className="phone-screen phone-inspect-overlay">

--- a/packages/vscode-extension/src/webview/components/Preview.tsx
+++ b/packages/vscode-extension/src/webview/components/Preview.tsx
@@ -302,6 +302,12 @@ function Preview({ isInspecting, setIsInspecting, zoomLevel, onZoomChanged }: Pr
       sendTouch(e, "Up");
       setIsPressing(false);
     }
+    if (isMultiTouching) {
+      sendMultiTouch(e, "Up");
+      setIsMultiTouching(false);
+      setIsPanning(false);
+      setIsMultiTouchVisible(false);
+    }
     if (isInspecting) {
       // we force inspect event here to make sure no extra events are throttled
       // and will be dispatched later on

--- a/packages/vscode-extension/src/webview/components/Preview.tsx
+++ b/packages/vscode-extension/src/webview/components/Preview.tsx
@@ -200,8 +200,6 @@ function Preview({ isInspecting, setIsInspecting, zoomLevel, onZoomChanged }: Pr
 
   function sendMultiTouch(event: MouseEvent<HTMLDivElement>, type: MouseMove) {
     const { x, y } = getTouchPosition(event);
-    setTouchPoint({ x, y });
-    setMirroredTouchPoint(getMirroredTouchPosition(anchorPoint));
     project.dispatchMultiTouch(x, y, anchorPoint.x, anchorPoint.y, type);
   }
 
@@ -251,17 +249,18 @@ function Preview({ isInspecting, setIsInspecting, zoomLevel, onZoomChanged }: Pr
 
   function onMouseMove(e: MouseEvent<HTMLDivElement>) {
     e.preventDefault();
-    if (isPressing) {
-      sendTouch(e, "Move");
-    } else if (isInspecting) {
-      sendInspect(e, "Move", false);
-    }
-
     if (isMultiTouching) {
       if (isPanning) {
         moveAnchorPoint(e);
       }
-      sendMultiTouch(e, "Move");
+      if (isPressing) {
+        sendMultiTouch(e, "Move");
+      }
+      setMirroredTouchPoint(getMirroredTouchPosition(anchorPoint));
+    } else if (isPressing) {
+      sendTouch(e, "Move");
+    } else if (isInspecting) {
+      sendInspect(e, "Move", false);
     }
     setTouchPoint(getTouchPosition(e));
   }
@@ -277,26 +276,24 @@ function Preview({ isInspecting, setIsInspecting, zoomLevel, onZoomChanged }: Pr
       resetInspector();
     } else if (e.button === 2) {
       sendInspect(e, "RightButtonDown", true);
+    } else if (isMultiTouching) {
+      setIsPressing(true);
+      sendMultiTouch(e, "Down");
+      setMirroredTouchPoint(getMirroredTouchPosition(anchorPoint));
     } else {
       setIsPressing(true);
       sendTouch(e, "Down");
-    }
-
-    if (isMultiTouching) {
-      sendMultiTouch(e, "Down");
     }
   }
 
   function onMouseUp(e: MouseEvent<HTMLDivElement>) {
     e.preventDefault();
-    if (isPressing) {
+    if (isMultiTouching) {
+      sendMultiTouch(e, "Up");
+    } else if (isPressing) {
       sendTouch(e, "Up");
     }
     setIsPressing(false);
-
-    if (isMultiTouching) {
-      sendMultiTouch(e, "Up");
-    }
   }
 
   function onMouseLeave(e: MouseEvent<HTMLDivElement>) {

--- a/packages/vscode-extension/src/webview/components/Preview.tsx
+++ b/packages/vscode-extension/src/webview/components/Preview.tsx
@@ -126,9 +126,7 @@ function Preview({ isInspecting, setIsInspecting, zoomLevel, onZoomChanged }: Pr
   const [isMultiTouching, setIsMultiTouching] = useState(false);
   const [isPanning, setIsPanning] = useState(false);
   const [touchPoint, setTouchPoint] = useState<TouchPoint>({ x: 0.5, y: 0.5 });
-  const [mirroredTouchPoint, setMirroredTouchPoint] = useState<TouchPoint>({ x: 0.5, y: 0.5 });
   const [anchorPoint, setAnchorPoint] = useState<TouchPoint>({ x: 0.5, y: 0.5 });
-  const [isMultiTouchVisible, setIsMultiTouchVisible] = useState(false);
   const previewRef = useRef<HTMLImageElement>(null);
   const [showPreviewRequested, setShowPreviewRequested] = useState(false);
 
@@ -252,7 +250,6 @@ function Preview({ isInspecting, setIsInspecting, zoomLevel, onZoomChanged }: Pr
     if (isMultiTouching) {
       isPanning && moveAnchorPoint(e);
       isPressing && sendMultiTouch(e, "Move");
-      setMirroredTouchPoint(getMirroredTouchPosition(anchorPoint));
     } else if (isPressing) {
       sendTouch(e, "Move");
     } else if (isInspecting) {
@@ -275,7 +272,6 @@ function Preview({ isInspecting, setIsInspecting, zoomLevel, onZoomChanged }: Pr
     } else if (isMultiTouching) {
       setIsPressing(true);
       sendMultiTouch(e, "Down");
-      setMirroredTouchPoint(getMirroredTouchPosition(anchorPoint));
     } else {
       setIsPressing(true);
       sendTouch(e, "Down");
@@ -302,7 +298,6 @@ function Preview({ isInspecting, setIsInspecting, zoomLevel, onZoomChanged }: Pr
       sendMultiTouch(e, "Up");
       setIsMultiTouching(false);
       setIsPanning(false);
-      setIsMultiTouchVisible(false);
     }
     if (isInspecting) {
       // we force inspect event here to make sure no extra events are throttled
@@ -340,12 +335,8 @@ function Preview({ isInspecting, setIsInspecting, zoomLevel, onZoomChanged }: Pr
         const isKeydown = e.type === "keydown";
 
         if (e.code === "AltLeft" || e.code === "AltRight") {
-          if (isKeydown) {
-            setAnchorPoint({ x: 0.5, y: 0.5 });
-            setMirroredTouchPoint(getMirroredTouchPosition({ x: 0.5, y: 0.5 }));
-          }
+          isKeydown && setAnchorPoint({ x: 0.5, y: 0.5 });
           setIsMultiTouching(isKeydown);
-          setIsMultiTouchVisible(isKeydown);
         }
         if (e.code === "ShiftLeft" || e.code === "ShiftRight") {
           setIsPanning(isKeydown);
@@ -361,7 +352,7 @@ function Preview({ isInspecting, setIsInspecting, zoomLevel, onZoomChanged }: Pr
       document.removeEventListener("keydown", keyEventHandler);
       document.removeEventListener("keyup", keyEventHandler);
     };
-  }, [project, touchPoint]);
+  }, [project]);
 
   useEffect(() => {
     if (projectStatus === "running") {
@@ -414,7 +405,7 @@ function Preview({ isInspecting, setIsInspecting, zoomLevel, onZoomChanged }: Pr
       borderStyle: "solid",
       transform: "translate(-50%, -50%)",
       boxShadow: isPressing ? "none" : "2px 2px 6px 1px rgba(0, 0, 0, 0.2)",
-      display: isMultiTouchVisible ? "block" : "none",
+      display: isMultiTouching ? "block" : "none",
     };
     return <div style={styles} />;
   };
@@ -440,7 +431,11 @@ function Preview({ isInspecting, setIsInspecting, zoomLevel, onZoomChanged }: Pr
                 />
 
                 <TouchPointMarker x={touchPoint.x} y={touchPoint.y} />
-                <TouchPointMarker x={mirroredTouchPoint.x} y={mirroredTouchPoint.y} />
+                <TouchPointMarker x={anchorPoint.x} y={anchorPoint.y} />
+                <TouchPointMarker
+                  x={getMirroredTouchPosition(anchorPoint).x}
+                  y={getMirroredTouchPosition(anchorPoint).y}
+                />
 
                 {inspectFrame && (
                   <div className="phone-screen phone-inspect-overlay">

--- a/packages/vscode-extension/src/webview/components/Preview.tsx
+++ b/packages/vscode-extension/src/webview/components/Preview.tsx
@@ -103,6 +103,33 @@ const MjpegImg = forwardRef<HTMLImageElement, React.ImgHTMLAttributes<HTMLImageE
   }
 );
 
+type TouchPointMarkerProps = {
+  x: number;
+  y: number;
+  isPressing: boolean;
+};
+
+function TouchPointMarker({ x, y, isPressing }: TouchPointMarkerProps) {
+  return (
+    <div
+      style={{
+        position: "absolute",
+        top: `${y * 100}%`,
+        left: `${x * 100}%`,
+        width: "33px",
+        height: "33px",
+        backgroundColor: "rgba(175, 175, 175, 0.75)",
+        borderRadius: "50%",
+        borderColor: "rgba(135, 135, 135, 0.6)",
+        borderWidth: "1px",
+        borderStyle: "solid",
+        transform: "translate(-50%, -50%)",
+        boxShadow: isPressing ? "none" : "2px 2px 6px 1px rgba(0, 0, 0, 0.2)",
+      }}
+    />
+  );
+}
+
 type InspectStackData = {
   requestLocation: { x: number; y: number };
   stack: InspectDataStackItem[];
@@ -391,24 +418,7 @@ function Preview({ isInspecting, setIsInspecting, zoomLevel, onZoomChanged }: Pr
     device: device!,
   });
 
-  const TouchPointMarker: React.FC<TouchPoint> = ({ x, y }) => {
-    const styles: React.CSSProperties = {
-      position: "absolute",
-      top: `${y * 100}%`,
-      left: `${x * 100}%`,
-      width: "33px",
-      height: "33px",
-      backgroundColor: "rgba(175, 175, 175, 0.75)",
-      borderRadius: "50%",
-      borderColor: "rgba(135, 135, 135, 0.6)",
-      borderWidth: "1px",
-      borderStyle: "solid",
-      transform: "translate(-50%, -50%)",
-      boxShadow: isPressing ? "none" : "2px 2px 6px 1px rgba(0, 0, 0, 0.2)",
-      display: isMultiTouching ? "block" : "none",
-    };
-    return <div style={styles} />;
-  };
+  const mirroredTouchPosition = getMirroredTouchPosition(anchorPoint);
 
   return (
     <>
@@ -430,12 +440,16 @@ function Preview({ isInspecting, setIsInspecting, zoomLevel, onZoomChanged }: Pr
                   className="phone-screen"
                 />
 
-                <TouchPointMarker x={touchPoint.x} y={touchPoint.y} />
-                <TouchPointMarker x={anchorPoint.x} y={anchorPoint.y} />
-                <TouchPointMarker
-                  x={getMirroredTouchPosition(anchorPoint).x}
-                  y={getMirroredTouchPosition(anchorPoint).y}
-                />
+                {isMultiTouching && (
+                  <TouchPointMarker x={touchPoint.x} y={touchPoint.y} isPressing={isPressing} />
+                )}
+                {isMultiTouching && (
+                  <TouchPointMarker
+                    x={mirroredTouchPosition.x}
+                    y={mirroredTouchPosition.y}
+                    isPressing={isPressing}
+                  />
+                )}
 
                 {inspectFrame && (
                   <div className="phone-screen phone-inspect-overlay">


### PR DESCRIPTION
This PR adds implementation of multitouch support for iOS and Android devices.
To use multitouch feature press and hold `Option` button, then two markers indicating touch points show up. While holding `Option` button and pressing `left mouse` button movements and button clicks ("up", "down") are sent to the sim-server subprocess. To pan touch points press `Option` and `Shift` buttons at the same time.  When the mouse leaves device's screen area, multitouch ends with "up" command.
Instead of `Option` button use `Alt` button on Windows.

⚠️After implementing the backend part in sim-server (#470) ensure that a proper multitouch command is set in `sendMultiTouch` function in `src/devices/preview.ts` file.

resolves: #449 