### PR TITLE
Fix pod install not exposing an error to the user

### DIFF
--- a/packages/vscode-extension/src/dependency/DependencyManager.ts
+++ b/packages/vscode-extension/src/dependency/DependencyManager.ts
@@ -318,6 +318,14 @@ export class DependencyManager implements Disposable {
     const iosDirPath = getIosSourceDir(appRootFolder);
 
     if (!iosDirPath) {
+      this.webview.postMessage({
+        command: "isPodsInstalled",
+        data: {
+          installed: false,
+          info: "Whether iOS dependencies are installed.",
+          error: "iOS directory does not exist",
+        },
+      });
       throw new Error(`ios directory was not found inside the workspace.`);
     }
 
@@ -331,11 +339,24 @@ export class DependencyManager implements Disposable {
       });
     };
 
-    if (forceCleanBuild) {
-      await cancelToken.adapt(commandInIosDir("pod deintegrate"));
-    }
+    try {
+      if (forceCleanBuild) {
+        await cancelToken.adapt(commandInIosDir("pod deintegrate"));
+      }
 
-    await cancelToken.adapt(commandInIosDir("pod install"));
+      await cancelToken.adapt(commandInIosDir("pod install"));
+    } catch (e) {
+      Logger.error("Pods not installed", e);
+      this.webview.postMessage({
+        command: "isPodsInstalled",
+        data: {
+          installed: false,
+          info: "Whether iOS dependencies are installed.",
+          error: "Unable to install pods",
+        },
+      });
+      return;
+    }
 
     this.stalePods = false;
 


### PR DESCRIPTION
After #457 pods not being installed is not considered an error, so an error message was removed. But sometimes the installation process it self might fail and this PR exposes that error to the user. 