### PR TITLE
Fix binding in EventDelegate in device session

### DIFF
--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -83,22 +83,22 @@ export class Project
   }
 
   //#region Build progress
-  onBuildProgress(stageProgress: number): void {
+  onBuildProgress = (stageProgress: number): void => {
     this.reportStageProgress(stageProgress, StartupMessage.Building);
-  }
+  };
 
-  onBuildSuccess(): void {
+  onBuildSuccess = (): void => {
     // reset fingerprint change flag when build finishes successfully
     this.detectedFingerprintChange = false;
-  }
+  };
 
-  onStateChange(state: StartupMessage): void {
+  onStateChange = (state: StartupMessage): void => {
     this.updateProjectStateForDevice(this.projectState.selectedDevice!, { startupMessage: state });
-  }
+  };
   //#endregion
 
   //#region App events
-  onAppEvent<E extends keyof AppEvent, P = AppEvent[E]>(event: E, payload: P): void {
+  onAppEvent = <E extends keyof AppEvent, P = AppEvent[E]>(event: E, payload: P): void => {
     switch (event) {
       case "navigationChanged":
         this.eventEmitter.emit("navigationChanged", payload);
@@ -114,7 +114,7 @@ export class Project
         this.updateProjectState({ status: "running" });
         break;
     }
-  }
+  };
   //#endregion
 
   //#region Debugger events


### PR DESCRIPTION
This PR fixes a bug introduced in #477, that caused deviceSession.buildApp call a method that was not properly bind, which resulted in the following error: 

```rejected promise not handled within 1 second: TypeError: Cannot set properties of undefined (setting 'detectedFingerprintChange')
extensionHostProcess.js:147
stack trace: TypeError: Cannot set properties of undefined (setting 'detectedFingerprintChange')
	at onBuildSuccess
``` 