### PR TITLE
Add nonce for inline script

### DIFF
--- a/packages/vscode-extension/src/panels/webviewContentGenerator.ts
+++ b/packages/vscode-extension/src/panels/webviewContentGenerator.ts
@@ -61,7 +61,7 @@ export function generateWebviewContent(
       </head>
       <body>
         <div id="root"></div>
-        <script>window.RNIDE_hostOS = "${Platform.OS}";</script>
+        <script nonce="${nonce}">window.RNIDE_hostOS = "${Platform.OS}";</script>
         <script type="module" nonce="${nonce}" src="${scriptUri}" />
       </body>
     </html>


### PR DESCRIPTION
Fixes "Refused to execute inline script because it violates the following Content Security Policy" error.