### PR TITLE
Fix navigation after Preview. 

### DIFF
--- a/packages/vscode-extension/lib/wrapper.js
+++ b/packages/vscode-extension/lib/wrapper.js
@@ -80,6 +80,8 @@ export function PreviewAppWrapper({ children, initialProps, ..._rest }) {
     mountCallback?.();
   }, [mountCallback]);
 
+  const layoutCallback = initialProps?.__RNIDE_onLayout;
+
   const handleNavigationChange = useCallback(
     (navigationDescriptor) => {
       navigationHistory.set(navigationDescriptor.id, navigationDescriptor);
@@ -117,7 +119,7 @@ export function PreviewAppWrapper({ children, initialProps, ..._rest }) {
       AppRegistry.runApplication("main", {
         rootTag,
         initialProps: {
-          __RNIDE_onMount: closePromiseResolve,
+          __RNIDE_onLayout: closePromiseResolve,
         },
       });
     } else {
@@ -281,6 +283,7 @@ export function PreviewAppWrapper({ children, initialProps, ..._rest }) {
       ref={mainContainerRef}
       style={{ flex: 1 }}
       onLayout={() => {
+        layoutCallback?.();
         setHasLayout(true);
       }}>
       {children}


### PR DESCRIPTION
This PR fixes a problem with navigation after using preview functionality. 
It turns out that navigation is not ready immediately  after mounting the wrapper component, the solution is to await layout instead. 

Bug: 
```
Attempted to navigate before mounting the Root Layout component. Ensure the Root Layout component is rendering a Slot, or other navigator on the first render.
```
To Reproduce: 

go to expo-51 example and try navigating from preview to any path in main application