### PR TITLE
Fix scheduler not being loaded

### DIFF
--- a/packages/vscode-extension/lib/metro_helpers.js
+++ b/packages/vscode-extension/lib/metro_helpers.js
@@ -84,6 +84,10 @@ function adaptMetroConfig(config) {
     extraNodeModulesPaths.push(path.join(next, "node_modules"));
   }
 
+  // because some libraries imported by the files in extension lib are not imported directly by an application, 
+  // but are imported by react native we need to add it's node_modules to the paths list
+  extraNodeModulesPaths.push(path.join(appRoot,"node_modules/react-native/node_modules"));
+
   config.resolver.nodeModulesPaths = [
     ...(config.resolver.nodeModulesPaths || []),
     ...extraNodeModulesPaths,


### PR DESCRIPTION
This pull request fixes an issue with scheduler not being loaded, when it wasn't an explicit dependency of an application.  The scheduler is an internal module for all react applications, you can find out more about it [here](https://github.com/facebook/react/tree/main/packages/scheduler).  Before our changes that replace React Native Renderer it was imported automatically by metro, because renderer was part of react-native package.  

Error message from the old version: 
```
Unable to resolve module scheduler from /Users/filip/Documents/react-native-ide/packages/vscode-extension/lib/rn-renderer/ReactNativeRenderer-dev.js: scheduler could not be found within the project or in these directories:
  ../../react-native-ide/packages/vscode-extension/node_modules
  node_modules
  29 |     require("react-native/Libraries/ReactPrivate/ReactNativePrivateInitializeCore");
  30 |     var ReactNativePrivateInterface = require("react-native/Libraries/ReactPrivate/ReactNativePrivateInterface");
> 31 |     var Scheduler = require("scheduler");
     |                              ^
  32 |
  33 |     var ReactSharedInternals =
  34 |       React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED;
```

Reproduction: 
To reproduce this issue run [this](https://github.com/software-mansion-labs/appjs-2024-workshop-reanimated) example application .

Fixes: #397 