### PR TITLE
Remove unwanted xcrun execution on Windows

### DIFF
--- a/packages/vscode-extension/src/webview/providers/DevicesProvider.tsx
+++ b/packages/vscode-extension/src/webview/providers/DevicesProvider.tsx
@@ -43,14 +43,14 @@ export default function DevicesProvider({ children }: PropsWithChildren) {
 
   const reload = useCallback(async () => {
     try {
-      await Promise.all([
+      const promises = [
         DeviceManager.listAllDevices().then(setDevices),
         DeviceManager.listInstalledAndroidImages().then(setAndroidImages),
-        ...Platform.select({
-          macos: [DeviceManager.listInstalledIOSRuntimes().then(setIOSRuntimes)],
-          windows: [],
-        }),
-      ]);
+      ];
+      if (Platform.OS === "macos") {
+        promises.push(DeviceManager.listInstalledIOSRuntimes().then(setIOSRuntimes));
+      }
+      await Promise.all(promises);
     } finally {
       setFinishedInitialLoad(true);
     }


### PR DESCRIPTION
This PR removes unwanted `DeviceManager.listInstalledIOSRuntimes` function call during platform selection in DevicesProvider.