### PR TITLE
Skip waiting to load on windows

### DIFF
--- a/packages/vscode-extension/src/builders/expoGo.ts
+++ b/packages/vscode-extension/src/builders/expoGo.ts
@@ -42,7 +42,7 @@ export async function isExpoGoProject(): Promise<boolean> {
     "expo_go_project_tester.js"
   );
   try {
-    const result = await exec(`node`, [expoGoProjectTesterScript], {
+    const result = await exec("node", [expoGoProjectTesterScript], {
       cwd: getAppRootFolder(),
       allowNonZeroExit: true,
     });
@@ -84,7 +84,7 @@ export function fetchExpoLaunchDeeplink(
 export async function downloadExpoGo(platform: DevicePlatform, cancelToken: CancelToken) {
   const downloadScript = path.join(extensionContext.extensionPath, "lib", "expo_go_download.js");
   const { stdout } = await cancelToken.adapt(
-    exec(`node`, [downloadScript, platform], {
+    exec("node", [downloadScript, platform], {
       cwd: getAppRootFolder(),
     })
   );

--- a/packages/vscode-extension/src/devices/AndroidEmulatorDevice.ts
+++ b/packages/vscode-extension/src/devices/AndroidEmulatorDevice.ts
@@ -495,7 +495,7 @@ async function ensureOldEmulatorProcessExited(avdId: string) {
 
 export async function removeEmulator(avdId: string) {
   // ensure to kill emulator process before removing avd files used by that process
-  if (Platform.OS == "windows") {
+  if (Platform.OS === "windows") {
     await ensureOldEmulatorProcessExited(avdId);
   }
 

--- a/packages/vscode-extension/src/devices/DeviceBase.ts
+++ b/packages/vscode-extension/src/devices/DeviceBase.ts
@@ -6,7 +6,6 @@ import { DeviceInfo, DevicePlatform } from "../common/DeviceManager";
 import { tryAcquiringLock } from "../utilities/common";
 
 import fs from "fs";
-import path from "path";
 
 export abstract class DeviceBase implements Disposable {
   private preview: Preview | undefined;

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -11,6 +11,7 @@ import { getLaunchConfiguration } from "../utilities/launchConfiguration";
 import { DebugSession, DebugSessionDelegate } from "../debugging/DebugSession";
 import { throttle } from "../utilities/throttle";
 import { DependencyManager } from "../dependency/DependencyManager";
+import { Platform } from "../utilities/platform";
 
 type StartOptions = { cleanBuild: boolean };
 
@@ -94,7 +95,13 @@ export class DeviceSession implements Disposable {
   }
 
   private async launchApp() {
-    const shouldWaitForAppLaunch = getLaunchConfiguration().preview?.waitForAppLaunch !== false;
+    // FIXME: Windows getting stuck waiting for the promise to resolve. This is
+    // caused by wrapper.js not being used as a wrapper, despite being used in
+    // runtime.js. runtime.js and Metro transforms are ran by JS engine.
+    const shouldWaitForAppLaunch = Platform.select({
+      macos: getLaunchConfiguration().preview?.waitForAppLaunch !== false,
+      windows: false,
+    });
     const waitForAppReady = shouldWaitForAppLaunch ? this.devtools.appReady() : Promise.resolve();
 
     this.eventDelegate.onStateChange(StartupMessage.Launching);

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -95,9 +95,9 @@ export class DeviceSession implements Disposable {
   }
 
   private async launchApp() {
-    // FIXME: Windows getting stuck waiting for the promise to resolve. This is
-    // caused by wrapper.js not being used as a wrapper, despite being used in
-    // runtime.js. runtime.js and Metro transforms are ran by JS engine.
+    // FIXME: Windows getting stuck waiting for the promise to resolve. This
+    // seems like a problem with app connecting to Metro and using embedded
+    // bundle instead.
     const shouldWaitForAppLaunch = Platform.select({
       macos: getLaunchConfiguration().preview?.waitForAppLaunch !== false,
       windows: false,

--- a/packages/vscode-extension/src/project/metro.ts
+++ b/packages/vscode-extension/src/project/metro.ts
@@ -109,7 +109,7 @@ export class Metro implements Disposable {
     return exec(
       `node`,
       [
-        `${reactNativeRoot}/cli.js`,
+        path.join(reactNativeRoot, "cli.js"),
         "start",
         ...(resetCache ? ["--reset-cache"] : []),
         "--no-interactive",

--- a/packages/vscode-extension/src/project/metro.ts
+++ b/packages/vscode-extension/src/project/metro.ts
@@ -90,7 +90,7 @@ export class Metro implements Disposable {
     resetCache: boolean,
     metroEnv: typeof process.env
   ) {
-    return exec(`node`, [path.join(libPath, "expo_start.js"), ...(resetCache ? ["--clear"] : [])], {
+    return exec("node", [path.join(libPath, "expo_start.js"), ...(resetCache ? ["--clear"] : [])], {
       cwd: appRootFolder,
       env: metroEnv,
       buffer: false,
@@ -107,7 +107,7 @@ export class Metro implements Disposable {
       require.resolve("react-native", { paths: [appRootFolder] })
     );
     return exec(
-      `node`,
+      "node",
       [
         path.join(reactNativeRoot, "cli.js"),
         "start",


### PR DESCRIPTION
There's currently an error which prevents sending `RNIDE_appReady` events. This results in IDE being stuck at "Waiting for an app to load" state. We workaround it on Windows to never wait.

This is caused by wrapper.js not being loaded as app's wrapper. This also means we can't use inspector functionality and other things that rely on communication with the app.