### PR TITLE
Change the behavior of useBundleErrorAlert 

### DIFF
--- a/packages/vscode-extension/src/webview/hooks/useBuildErrorAlert.tsx
+++ b/packages/vscode-extension/src/webview/hooks/useBuildErrorAlert.tsx
@@ -65,17 +65,17 @@ function BundleErrorActions() {
       <IconButton
         type="secondary"
         onClick={() => {
-          project.focusBuildOutput();
+          project.focusDebugConsole();
         }}
-        tooltip={{ label: "Open build logs", side: "bottom" }}>
-        <span className="codicon codicon-symbol-keyword" />
+        tooltip={{ label: "Open debug console", side: "bottom" }}>
+        <span className="codicon codicon-debug-console" />
       </IconButton>
       <IconButton
         type="secondary"
         onClick={() => {
-          project.restart(false);
+          project.reload("reloadJs");
         }}
-        tooltip={{ label: "Reload IDE", side: "bottom" }}>
+        tooltip={{ label: "Reload Metro", side: "bottom" }}>
         <span className="codicon codicon-refresh" />
       </IconButton>
     </>
@@ -85,7 +85,7 @@ function BundleErrorActions() {
 const bundleErrorAlert = {
   id: "bundle-error-alert",
   title: "Bundle error",
-  description: "Open build logs to find out what went wrong.",
+  description: "Open application logs to find out what went wrong.",
   actions: <BundleErrorActions />,
 };
 


### PR DESCRIPTION
This PR fixes useBundleErrorAlert which previously was modeled on useBuildErrorAlert and had options that were not really useful in bundle error case. 

Before: 
<img width="523" alt="Screenshot 2024-08-23 at 11 00 55" src="https://github.com/user-attachments/assets/d63db6c6-8fe8-4c09-b8ad-8e1c7791d795">

After: 
<img width="520" alt="Screenshot 2024-08-23 at 10 55 03" src="https://github.com/user-attachments/assets/59644c30-7511-417c-b97a-064fc31ae9fd">
<img width="505" alt="Screenshot 2024-08-23 at 10 55 46" src="https://github.com/user-attachments/assets/661330c3-dbff-4752-8d44-304f3ddf6bfd">
<img width="523" alt="Screenshot 2024-08-23 at 10 54 55" src="https://github.com/user-attachments/assets/04c323ad-8f52-4199-be61-17ef8308185d">
