### PR TITLE
Set environment on startup

### DIFF
--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -23,9 +23,7 @@ import {
   setAppRootFolder,
   setExtensionContext,
 } from "./utilities/extensionContext";
-import { command } from "./utilities/subprocess";
-import path from "path";
-import os from "os";
+import { command, setupPathEnv } from "./utilities/subprocess";
 import fs from "fs";
 import { SidePanelViewProvider } from "./panels/SidepanelViewProvider";
 import { PanelLocation } from "./common/WorkspaceConfig";
@@ -88,7 +86,18 @@ export async function activate(context: ExtensionContext) {
   commands.executeCommand("setContext", "RNIDE.sidePanelIsClosed", false);
 
   async function showIDEPanel(fileName?: string, lineNumber?: number) {
-    commands.executeCommand("setContext", "RNIDE.sidePanelIsClosed", false);
+    await commands.executeCommand("setContext", "RNIDE.sidePanelIsClosed", false);
+
+    if (Platform.OS === "macos") {
+      try {
+        await setupPathEnv();
+      } catch (error) {
+        window.showWarningMessage(
+          "Error when setting up PATH environment variable, RN IDE may not work correctly.",
+          "Dismiss"
+        );
+      }
+    }
     const panelLocation = workspace
       .getConfiguration("ReactNativeIDE")
       .get<PanelLocation>("panelLocation");

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -88,16 +88,6 @@ export async function activate(context: ExtensionContext) {
   async function showIDEPanel(fileName?: string, lineNumber?: number) {
     await commands.executeCommand("setContext", "RNIDE.sidePanelIsClosed", false);
 
-    if (Platform.OS === "macos") {
-      try {
-        await setupPathEnv();
-      } catch (error) {
-        window.showWarningMessage(
-          "Error when setting up PATH environment variable, RN IDE may not work correctly.",
-          "Dismiss"
-        );
-      }
-    }
     const panelLocation = workspace
       .getConfiguration("ReactNativeIDE")
       .get<PanelLocation>("panelLocation");
@@ -223,6 +213,19 @@ export async function activate(context: ExtensionContext) {
   );
 
   await configureAppRootFolder();
+
+  if (Platform.OS === "macos") {
+    try {
+      await setupPathEnv();
+    } catch (error) {
+      window.showWarningMessage(
+        "Error when setting up PATH environment variable, RN IDE may not work correctly.",
+        "Dismiss"
+      );
+    }
+  }
+
+  extensionActivated();
 }
 
 class LaunchConfigDebugAdapterDescriptorFactory implements vscode.DebugAdapterDescriptorFactory {
@@ -248,7 +251,6 @@ async function configureAppRootFolder() {
     Logger.info(`Found app root folder: ${appRootFolder}`);
     setAppRootFolder(appRootFolder);
     commands.executeCommand("setContext", "RNIDE.extensionIsActive", true);
-    extensionActivated();
   }
   return appRootFolder;
 }

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -212,11 +212,14 @@ export async function activate(context: ExtensionContext) {
     })
   );
 
-  await configureAppRootFolder();
+  const appRoot = await configureAppRootFolder();
+  if (!appRoot) {
+    return;
+  }
 
   if (Platform.OS === "macos") {
     try {
-      await setupPathEnv();
+      await setupPathEnv(appRoot);
     } catch (error) {
       window.showWarningMessage(
         "Error when setting up PATH environment variable, RN IDE may not work correctly.",

--- a/packages/vscode-extension/src/utilities/subprocess.ts
+++ b/packages/vscode-extension/src/utilities/subprocess.ts
@@ -24,10 +24,15 @@ export async function getPathEnv() {
     // which won't be triggered when running a ZSH in a subprocess.
 
     // fish, bash, and zsh all support -i and -c flags
-    const { stdout: miseEnv } = await nodeExec(
-      `${shellPath} -i -c 'whence mise > /dev/null && mise hook-env | grep \"PATH=\"'`
-    );
-    return extractLastPathVariable(miseEnv);
+    try {
+      const { stdout: miseEnv } = await nodeExec(
+        `${shellPath} -i -c 'mise hook-env | grep \"PATH=\"'`
+      );
+      return extractLastPathVariable(miseEnv);
+    } catch (_error) {
+      // mise isn't installed
+      return undefined;
+    }
   }
 
   async function getEnv(shellPath: string) {

--- a/packages/vscode-extension/src/utilities/subprocess.ts
+++ b/packages/vscode-extension/src/utilities/subprocess.ts
@@ -2,11 +2,10 @@ import { Logger } from "../Logger";
 import execa, { ExecaChildProcess } from "execa";
 import readline from "readline";
 import { Platform } from "./platform";
-import { getAppRootFolder } from "./extensionContext";
 
 export type ChildProcess = ExecaChildProcess<string>;
 
-export async function getPathEnv() {
+async function getPathEnv(appRoot: string) {
   // We run an interactive shell session to make sure that tool managers (nvm,
   // asdf, mise, etc.) are loaded and PATH is set correctly. Mise in
   // particular sets the PATH by hooking into change dir and prompt display
@@ -17,15 +16,14 @@ export async function getPathEnv() {
 
   // Fish, bash, and zsh all support -i and -c flags.
   const shellPath = process.env.SHELL ?? "/bin/zsh";
-  const appRoot = getAppRootFolder();
   const { stdout: path } = await execa(shellPath, ["-i", "-c", `cd "${appRoot}" && echo "$PATH"`]);
   return path.trim();
 }
 
 let pathEnv: string | undefined;
-export async function setupPathEnv() {
+export async function setupPathEnv(appRoot: string) {
   if (!pathEnv) {
-    pathEnv = await getPathEnv();
+    pathEnv = await getPathEnv(appRoot);
     if (!pathEnv) {
       throw new Error("Error in getting PATH environment variable");
     }


### PR DESCRIPTION
When launching VS Code from Applications, we sometimes get a `PATH` env var that doesn't have path to node, npm, or other tools. This happens because some tool managers like nvm, asdf, mise, etc update `PATH` only in rc files, which are only used when launching shells interactively.

To prevent errors, we start user's shell (or ZSH in case $SHELL isn't defined) interactively once when opening IDE panel for the first time and use its env with execa. In case of an error, we show a warning a proceed.

## Testing
To test this, run VS Code from applications, comment out `preLaunchTask` in `launch.json`, run `npm run build:extension-debug` and `npm run watch:extension` and launch extension development task (F5 or run launch.json).

You should not see any error in debug console and extension should work correctly.