### PR TITLE
Fix wrapper to work on Windows

### DIFF
--- a/packages/vscode-extension/lib/babel_transformer.js
+++ b/packages/vscode-extension/lib/babel_transformer.js
@@ -52,11 +52,15 @@ overrideModuleFromAppDir("@babel/plugin-transform-react-jsx-self", {
   visitor: {},
 });
 
-function transformWrapper({ filename, src, ...rest }) {
+function transformWrapper({ filename, src, options, plugins }) {
+  function isTransforming(unixPath) {
+    return filename.endsWith(path.normalize(unixPath));
+  }
+
   const { transform } = require(ORIGINAL_TRANSFORMER_PATH);
-  if (filename.endsWith("node_modules/react-native/Libraries/Core/InitializeCore.js")) {
+  if (isTransforming("node_modules/react-native/Libraries/Core/InitializeCore.js")) {
     src = `${src};require("__RNIDE_lib__/runtime.js");`;
-  } else if (filename.endsWith("node_modules/expo-router/entry.js")) {
+  } else if (isTransforming("node_modules/expo-router/entry.js")) {
     // expo-router v2 and v3 integration
     const { version } = requireFromAppDir("expo-router/package.json");
     if (version.startsWith("2.")) {
@@ -64,13 +68,13 @@ function transformWrapper({ filename, src, ...rest }) {
     } else if (version.startsWith("3.")) {
       src = `${src};require("__RNIDE_lib__/expo_router_plugin.js");`;
     }
-  } else if (filename.endsWith("node_modules/react-native-ide/index.js")) {
+  } else if (isTransforming("node_modules/react-native-ide/index.js")) {
     src = `${src};preview = require("__RNIDE_lib__/preview.js").preview;`;
   } else if (
-    filename.endsWith(
+    isTransforming(
       "node_modules/react-native/Libraries/Renderer/implementations/ReactFabric-dev.js"
     ) ||
-    filename.endsWith(
+    isTransforming(
       "node_modules/react-native/Libraries/Renderer/implementations/ReactNativeRenderer-dev.js"
     )
   ) {
@@ -97,7 +101,7 @@ function transformWrapper({ filename, src, ...rest }) {
     }
   }
 
-  return transform({ filename, src, ...rest });
+  return transform({ filename, src, options, plugins });
 }
 
 module.exports = { transform: transformWrapper };

--- a/packages/vscode-extension/lib/babel_transformer.js
+++ b/packages/vscode-extension/lib/babel_transformer.js
@@ -52,7 +52,7 @@ overrideModuleFromAppDir("@babel/plugin-transform-react-jsx-self", {
   visitor: {},
 });
 
-function transformWrapper({ filename, src, options, plugins }) {
+function transformWrapper({ filename, src, ...rest }) {
   function isTransforming(unixPath) {
     return filename.endsWith(path.normalize(unixPath));
   }
@@ -101,7 +101,7 @@ function transformWrapper({ filename, src, options, plugins }) {
     }
   }
 
-  return transform({ filename, src, options, plugins });
+  return transform({ filename, src, ...rest });
 }
 
 module.exports = { transform: transformWrapper };

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -98,10 +98,7 @@ export class DeviceSession implements Disposable {
     // FIXME: Windows getting stuck waiting for the promise to resolve. This
     // seems like a problem with app connecting to Metro and using embedded
     // bundle instead.
-    const shouldWaitForAppLaunch = Platform.select({
-      macos: getLaunchConfiguration().preview?.waitForAppLaunch !== false,
-      windows: false,
-    });
+    const shouldWaitForAppLaunch = getLaunchConfiguration().preview?.waitForAppLaunch !== false;
     const waitForAppReady = shouldWaitForAppLaunch ? this.devtools.appReady() : Promise.resolve();
 
     this.eventDelegate.onStateChange(StartupMessage.Launching);


### PR DESCRIPTION
We're using filenames which are platform-specific to check what files should be modified. Windows uses backslashes so it wasn't ever matched.

## Testing plan

Run any app on windows and check if RN IDE functionality works (inspector, etc).