### PR TITLE
Fix babel transformer not working.

### DIFF
--- a/packages/vscode-extension/lib/babel_transformer.js
+++ b/packages/vscode-extension/lib/babel_transformer.js
@@ -1,3 +1,5 @@
+const path = require("path");
+
 const ORIGINAL_TRANSFORMER_PATH = process.env.REACT_NATIVE_IDE_ORIG_BABEL_TRANSFORMER_PATH;
 
 const { requireFromAppDir, overrideModuleFromAppDir } = require("./metro_helpers");


### PR DESCRIPTION
This PR adds missing import from babel_transformer.js file. 
While in some setups the import was added to the "main" file before it was needed by the babel_transformer, tests on macOS 15 reviled that it is not always the case, resulting in the following metro error:

```
{
    "error": {
        "type": "TransformError",
        "lineNumber": 0,
        "errors": [
            {
                "description": "index.js: path is not defined",
                "lineNumber": 0
            }
        ]
    },
    "type": "bundling_error",
    "message": "index.js: path is not defined",
    "stack": "ReferenceError: path is not defined\n    at isTransforming (/Users/filip/Documents/react-native-ide/packages/vscode-extension/lib/babel_transformer.js:57:30)\n    at Object.transformWrapper [as transform] (/Users/filip/Documents/react-native-ide/packages/vscode-extension/lib/babel_transformer.js:61:7)\n    at transformJSWithBabel (/Users/filip/Documents/test/bare2/node_modules/metro-transform-worker/src/index.js:288:45)\n    at Object.transform (/Users/filip/Documents/test/bare2/node_modules/metro-transform-worker/src/index.js:413:18)\n    at transformFile (/Users/filip/Documents/test/bare2/node_modules/metro/src/DeltaBundler/Worker.flow.js:54:36)\n    at Object.transform (/Users/filip/Documents/test/bare2/node_modules/metro/src/DeltaBundler/Worker.flow.js:30:10)\n    at execFunction (/Users/filip/Documents/test/bare2/node_modules/jest-worker/build/workers/processChild.js:149:17)\n    at execHelper (/Users/filip/Documents/test/bare2/node_modules/jest-worker/build/workers/processChild.js:137:5)\n    at execMethod (/Users/filip/Documents/test/bare2/node_modules/jest-worker/build/workers/processChild.js:140:5)"
}
```

relates to: #520 