### PR TITLE
Update startup messages wrapping in Preview Loader

### DIFF
--- a/packages/vscode-extension/src/webview/components/PreviewLoader.css
+++ b/packages/vscode-extension/src/webview/components/PreviewLoader.css
@@ -8,7 +8,7 @@
   justify-content: space-between;
   align-items: center;
   margin-bottom: 8px;
-  flex-wrap: wrap
+  flex-wrap: wrap;
 }
 
 .preview-loader-message-wrapper {

--- a/packages/vscode-extension/src/webview/components/PreviewLoader.css
+++ b/packages/vscode-extension/src/webview/components/PreviewLoader.css
@@ -5,9 +5,10 @@
 
 .preview-loader-button-group {
   display: flex;
-  justify-content: flex-end;
+  justify-content: space-between;
   align-items: center;
   margin-bottom: 8px;
+  flex-wrap: wrap
 }
 
 .preview-loader-message-wrapper {

--- a/packages/vscode-extension/src/webview/components/shared/StartupMessage.css
+++ b/packages/vscode-extension/src/webview/components/shared/StartupMessage.css
@@ -1,6 +1,9 @@
 .startup-message-wrapper {
   display: flex;
   color: var(--swm-startup-message);
+  width: fit-content;
+  white-space: normal;
+  align-items: flex-end;
 }
 
 .startup-message-dots {


### PR DESCRIPTION
This PR updates CSS for startup messages in Preview Loader to ensure proper wrapping on smaller device displays.

Before:
<img width="308" alt="Screenshot 2024-09-04 at 15 30 02" src="https://github.com/user-attachments/assets/238973c7-fbad-4f1a-ad07-01afa7a085be">

After:
<img width="308" alt="Screenshot 2024-09-04 at 15 29 52" src="https://github.com/user-attachments/assets/b2d4b9bb-d001-4462-bdf8-393733e4c26d">
