### PR TITLE
Update prettier call in lint command to use npm

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -276,7 +276,7 @@
     "build:dist": "npm run build:extension && npm run build:sim-server && npm run build:webview",
     "watch:extension": "vite",
     "package": "rm -rf dist/ && npm run build:dist",
-    "lint": "eslint src --ext ts && yarn prettier --check src",
+    "lint": "eslint src --ext ts && npm exec prettier --check src",
     "format": "prettier --write --list-different src",
     "build:tests": "tsc --project tsconfig.test.json",
     "test": "npm run build:extension-code && npm run build:webview && npm run build:tests && vscode-test"

--- a/packages/vscode-extension/src/debugging/DebugAdapter.ts
+++ b/packages/vscode-extension/src/debugging/DebugAdapter.ts
@@ -502,7 +502,7 @@ export class DebugAdapter extends DebugSession {
         );
         if (newId !== null) {
           bp.setId(newId);
-          bp.verified = true;;
+          bp.verified = true;
         } else {
           bp.verified = false;
         }

--- a/packages/vscode-extension/src/debugging/DebugAdapter.ts
+++ b/packages/vscode-extension/src/debugging/DebugAdapter.ts
@@ -502,7 +502,7 @@ export class DebugAdapter extends DebugSession {
         );
         if (newId !== null) {
           bp.setId(newId);
-          bp.verified = true;
+          bp.verified = true;;
         } else {
           bp.verified = false;
         }


### PR DESCRIPTION
This PR updates call to prettier from lint script to use npm.

Previously the script would use `yarn prettier` to call prettier from `node_modules/.bin`, however, this comand fails now with newer version of yarn as the new yarn thinks this project is a yarn workspace project (due to package.json structure) which is not the case.

Since we're using `npm` as package manager, it's better to stick to it instead of relying on yarn for simple script calls. 

This PR updates `yarn prettier` command to call `npm exec prettier` instead.

