### PR TITLE
Rename react native IDE to Radon IDE (the parts visible to the user)

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-ide",
-  "displayName": "React Native IDE",
+  "displayName": "Radon IDE",
   "description": "Extension turning VSCode into a full-featured IDE for React Native and Expo",
   "publisher": "swmansion",
   "categories": [
@@ -34,44 +34,44 @@
       {
         "command": "RNIDE.openDevMenu",
         "title": "Open Dev Menu",
-        "category": "React Native IDE",
+        "category": "Radon IDE",
         "enablement": "RNIDE.extensionIsActive"
       },
       {
         "command": "RNIDE.closePanel",
         "title": "Close IDE Panel",
-        "category": "React Native IDE",
+        "category": "Radon IDE",
         "icon": "$(close)",
         "enablement": "RNIDE.extensionIsActive"
       },
       {
         "command": "RNIDE.openPanel",
         "title": "Open IDE Panel",
-        "category": "React Native IDE",
+        "category": "Radon IDE",
         "enablement": "RNIDE.extensionIsActive && !RNIDE.panelIsOpen"
       },
       {
         "command": "RNIDE.showPanel",
         "title": "Show IDE Panel",
-        "category": "React Native IDE",
+        "category": "Radon IDE",
         "enablement": "RNIDE.extensionIsActive && RNIDE.panelIsOpen"
       },
       {
         "command": "RNIDE.diagnose",
         "title": "Diagnostics",
-        "category": "React Native IDE",
+        "category": "Radon IDE",
         "enablement": "!RNIDE.extensionIsActive"
       },
       {
         "command": "RNIDE.performBiometricAuthorization",
         "title": "Perform Biometric Authorization ",
-        "category": "React Native IDE",
+        "category": "Radon IDE",
         "enablement": "RNIDE.extensionIsActive"
       },
       {
         "command": "RNIDE.performFailedBiometricAuthorization",
         "title": "Perform Failed Biometric Authorization",
-        "category": "React Native IDE",
+        "category": "Radon IDE",
         "enablement": "RNIDE.extensionIsActive"
       }
     ],
@@ -99,9 +99,9 @@
       }
     ],
     "configuration": {
-      "title": "React Native IDE",
+      "title": "Radon IDE",
       "properties": {
-        "ReactNativeIDE.panelLocation": {
+        "RadonIDE.panelLocation": {
           "type": "string",
           "scope": "window",
           "default": "tab",
@@ -112,13 +112,13 @@
           ],
           "description": "Controlls location of the IDE panel. Due to vscode API limitations, when secondary side panel is selected, you need to manually move the IDE panel to the secondary side panel. Changing this option closes and reopens the IDE."
         },
-        "ReactNativeIDE.showDeviceFrame": {
+        "RadonIDE.showDeviceFrame": {
           "type": "boolean",
           "scope": "window",
           "default": true,
           "description": "Shows device frame in the IDE panel."
         },
-        "ReactNativeIDE.inspectorExcludePattern": {
+        "RadonIDE.inspectorExcludePattern": {
           "type": "string",
           "scope": "window",
           "default": null,
@@ -129,19 +129,19 @@
     "viewsContainers": {
       "activitybar": [
         {
-          "id": "ReactNativeIDE",
-          "title": "React Native IDE",
+          "id": "RadonIDE",
+          "title": "Radon IDE",
           "icon": "assets/logo.svg"
         }
       ]
     },
     "views": {
-      "ReactNativeIDE": [
+      "RadonIDE": [
         {
           "type": "webview",
-          "id": "ReactNativeIDE.view",
+          "id": "RadonIDE.view",
           "name": "",
-          "when": "config.ReactNativeIDE.panelLocation != 'tab' && !RNIDE.sidePanelIsClosed"
+          "when": "config.RadonIDE.panelLocation != 'tab' && !RNIDE.sidePanelIsClosed"
         }
       ]
     },
@@ -157,7 +157,7 @@
         {
           "command": "RNIDE.closePanel",
           "group": "navigation",
-          "when": "RNIDE.extensionIsActive && RNIDE.panelIsOpen && view == ReactNativeIDE.view"
+          "when": "RNIDE.extensionIsActive && RNIDE.panelIsOpen && view == RadonIDE.view"
         }
       ]
     },
@@ -251,9 +251,9 @@
         },
         "initialConfigurations": [
           {
-            "type": "react-native-ide",
+            "type": "radon-ide",
             "request": "launch",
-            "name": "React Native IDE panel",
+            "name": "Radon IDE panel",
             "ios": {
               "configuration": "Debug"
             },
@@ -265,7 +265,8 @@
       },
       {
         "type": "react-native-ide",
-        "label": "React Native IDE",
+        "label": "Radon IDE",
+        "deprecated": "true",
         "languages": [
           "javascript",
           "typescript",
@@ -337,7 +338,7 @@
           {
             "type": "react-native-ide",
             "request": "launch",
-            "name": "React Native IDE panel",
+            "name": "Radon IDE panel",
             "ios": {
               "configuration": "Debug"
             },

--- a/packages/vscode-extension/src/Logger.ts
+++ b/packages/vscode-extension/src/Logger.ts
@@ -1,6 +1,6 @@
 import { window } from "vscode";
 
-const outputChannel = window.createOutputChannel("React Native IDE", { log: true });
+const outputChannel = window.createOutputChannel("Radon IDE", { log: true });
 
 const logger = {
   log(_message: string, ..._args: any[]) {},

--- a/packages/vscode-extension/src/builders/BuildManager.ts
+++ b/packages/vscode-extension/src/builders/BuildManager.ts
@@ -57,7 +57,7 @@ export class BuildManager {
 
       let buildResult: BuildResult;
       if (platform === DevicePlatform.Android) {
-        this.buildOutputChannel = window.createOutputChannel("React Native IDE (Android build)", {
+        this.buildOutputChannel = window.createOutputChannel("Radon IDE (Android build)", {
           log: true,
         });
         buildResult = await buildAndroid(
@@ -68,7 +68,7 @@ export class BuildManager {
           progressListener
         );
       } else {
-        this.buildOutputChannel = window.createOutputChannel("React Native IDE (iOS build)", {
+        this.buildOutputChannel = window.createOutputChannel("Radon IDE (iOS build)", {
           log: true,
         });
         buildResult = await buildIos(

--- a/packages/vscode-extension/src/integration-tests/extension.test.ts
+++ b/packages/vscode-extension/src/integration-tests/extension.test.ts
@@ -13,7 +13,7 @@ test("Shows error on Linux", async () => {
 
   await getExtension().activate();
 
-  assert.ok(showErrorMessage.calledOnceWith("React Native IDE works only on macOS and Windows."));
+  assert.ok(showErrorMessage.calledOnceWith("Radon IDE works only on macOS and Windows."));
 });
 
 function stubLinuxPlatform() {

--- a/packages/vscode-extension/src/panels/LaunchConfigController.ts
+++ b/packages/vscode-extension/src/panels/LaunchConfigController.ts
@@ -78,9 +78,9 @@ export class LaunchConfigController implements Disposable, LaunchConfig {
 
     if (!RNIDEConfigurationExits) {
       newConfigurations?.push({
-        type: "react-native-ide", // TODO: this should be renamed but will be visible to users
+        type: "radon-ide",
         request: "launch",
-        name: "React Native IDE panel",
+        name: "Radon IDE panel",
         ...newLaunchConfig,
       });
     }

--- a/packages/vscode-extension/src/panels/SidepanelViewProvider.ts
+++ b/packages/vscode-extension/src/panels/SidepanelViewProvider.ts
@@ -13,7 +13,7 @@ import { WebviewController } from "./WebviewController";
 import { Logger } from "../Logger";
 
 export class SidePanelViewProvider implements WebviewViewProvider, Disposable {
-  public static readonly viewType = "ReactNativeIDE.view";
+  public static readonly viewType = "RadonIDE.view";
   public static currentProvider: SidePanelViewProvider | undefined;
   private _view: any = null;
   public get view(): any {
@@ -40,9 +40,7 @@ export class SidePanelViewProvider implements WebviewViewProvider, Disposable {
   public static showView(context: ExtensionContext, fileName?: string, lineNumber?: number) {
     if (SidePanelViewProvider.currentProvider) {
       commands.executeCommand(`${SidePanelViewProvider.viewType}.focus`);
-      if (
-        workspace.getConfiguration("ReactNativeIDE").get("panelLocation") === "secondary-side-panel"
-      ) {
+      if (workspace.getConfiguration("RadonIDE").get("panelLocation") === "secondary-side-panel") {
         commands.executeCommand("workbench.action.focusAuxiliaryBar");
       }
     } else {

--- a/packages/vscode-extension/src/panels/Tabpanel.ts
+++ b/packages/vscode-extension/src/panels/Tabpanel.ts
@@ -48,10 +48,10 @@ export class TabPanel implements Disposable {
     this.webviewController = new WebviewController(this._panel.webview);
 
     workspace.onDidChangeConfiguration((event: ConfigurationChangeEvent) => {
-      if (!event.affectsConfiguration("ReactNativeIDE")) {
+      if (!event.affectsConfiguration("RadonIDE")) {
         return;
       }
-      if (workspace.getConfiguration("ReactNativeIDE").get("panelLocation") !== "tab") {
+      if (workspace.getConfiguration("RadonIDE").get("panelLocation") !== "tab") {
         this.dispose();
       }
     });
@@ -69,7 +69,7 @@ export class TabPanel implements Disposable {
 
       const panel = window.createWebviewPanel(
         "radon-ide-panel",
-        "React Native IDE",
+        "Radon IDE",
         { viewColumn: emptyGroup?.viewColumn || ViewColumn.Beside },
         {
           enableScripts: true,

--- a/packages/vscode-extension/src/panels/WorkspaceConfigController.ts
+++ b/packages/vscode-extension/src/panels/WorkspaceConfigController.ts
@@ -14,17 +14,17 @@ export class WorkspaceConfigController implements Disposable, WorkspaceConfig {
   private configListener: Disposable | undefined;
 
   constructor() {
-    const configuration = workspace.getConfiguration("ReactNativeIDE");
+    const configuration = workspace.getConfiguration("RadonIDE");
     this.config = {
       panelLocation: configuration.get<PanelLocation>("panelLocation")!,
       showDeviceFrame: configuration.get<boolean>("showDeviceFrame")!,
     };
 
     this.configListener = workspace.onDidChangeConfiguration((event: ConfigurationChangeEvent) => {
-      if (!event.affectsConfiguration("ReactNativeIDE")) {
+      if (!event.affectsConfiguration("RadonIDE")) {
         return;
       }
-      const config = workspace.getConfiguration("ReactNativeIDE");
+      const config = workspace.getConfiguration("RadonIDE");
       this.config = {
         panelLocation: config.get<PanelLocation>("panelLocation")!,
         showDeviceFrame: config.get<boolean>("showDeviceFrame")!,
@@ -38,7 +38,7 @@ export class WorkspaceConfigController implements Disposable, WorkspaceConfig {
   }
 
   async update<K extends keyof WorkspaceConfigProps>(key: K, value: WorkspaceConfigProps[K]) {
-    const configuration = workspace.getConfiguration("ReactNativeIDE");
+    const configuration = workspace.getConfiguration("RadonIDE");
     if (configuration.inspect(key as string)?.workspaceValue) {
       await configuration.update(key as string, value, false);
     } else {

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -356,7 +356,7 @@ export class Project
       if (requestStack && inspectData?.stack) {
         stack = inspectData.stack;
         const inspectorExcludePattern = workspace
-          .getConfiguration("ReactNativeIDE")
+          .getConfiguration("RadonIDE")
           .get("inspectorExcludePattern") as string | undefined;
         const patterns = inspectorExcludePattern?.split(",").map((pattern) => pattern.trim());
         function testInspectorExcludeGlobPattern(filename: string) {
@@ -478,7 +478,7 @@ export class Project
     } catch (e) {
       if (e instanceof DeviceAlreadyUsedError) {
         window.showErrorMessage(
-          "This device is already used by other instance of React Native IDE.\nPlease select another device",
+          "This device is already used by other instance of Radon IDE.\nPlease select another device",
           "Dismiss"
         );
       } else {


### PR DESCRIPTION
This phase 3 of renaming React Native IDE to Radon IDE.

This part touches the elements in the extension user interface that were using the old name including vscode configuration, launch configuration, command names and error messages.

As part of this PR we are adding a small migration function to copy global configuration. It runs in the extension activation phase before we start initializing the panel.

After this phase the things that are left are:
 - [ ] public README
 - [ ] repo name and links to the repository
 - [ ] we can consider cache dir location change

## Test plan

Run expo-router app on Android iOS
With the previous version change panel location -> see this setting is kept across the configuration name change
Test keybindings
