### PR TITLE
Modify line reader to always consume stderr and mark stderr in callback

### DIFF
--- a/packages/vscode-extension/src/builders/buildAndroid.ts
+++ b/packages/vscode-extension/src/builders/buildAndroid.ts
@@ -120,7 +120,7 @@ export async function buildAndroid(
   );
   const buildAndroidProgressProcessor = new BuildAndroidProgressProcessor(progressListener);
   outputChannel.clear();
-  lineReader(buildProcess, true).onLineRead((line) => {
+  lineReader(buildProcess).onLineRead((line) => {
     outputChannel.appendLine(line);
     buildAndroidProgressProcessor.processLine(line);
   });

--- a/packages/vscode-extension/src/builders/buildIOS.ts
+++ b/packages/vscode-extension/src/builders/buildIOS.ts
@@ -126,7 +126,7 @@ export async function buildIos(
 
     const buildIOSProgressProcessor = new BuildIOSProgressProcessor(progressListener);
     outputChannel.clear();
-    lineReader(process, true).onLineRead((line) => {
+    lineReader(process).onLineRead((line) => {
       outputChannel.appendLine(line);
       buildIOSProgressProcessor.processLine(line);
       // Xcode can sometimes escape `=` with a backslash or put the value in quotes

--- a/packages/vscode-extension/src/devices/preview.ts
+++ b/packages/vscode-extension/src/devices/preview.ts
@@ -37,7 +37,12 @@ export class Preview implements Disposable {
 
       const streamURLRegex = /(http:\/\/[^ ]*stream\.mjpeg)/;
 
-      lineReader(subprocess).onLineRead((line) => {
+      lineReader(subprocess).onLineRead((line, stderr) => {
+        if (stderr) {
+          Logger.warn("sim-server err:", line);
+          return;
+        }
+
         const match = line.match(streamURLRegex);
 
         if (match) {
@@ -46,7 +51,7 @@ export class Preview implements Disposable {
           this.streamURL = match[1];
           resolve(this.streamURL);
         }
-        Logger.debug("Preview server:", line);
+        Logger.debug("sim-server out:", line);
       });
     });
   }

--- a/packages/vscode-extension/src/devices/preview.ts
+++ b/packages/vscode-extension/src/devices/preview.ts
@@ -39,19 +39,19 @@ export class Preview implements Disposable {
 
       lineReader(subprocess).onLineRead((line, stderr) => {
         if (stderr) {
-          Logger.warn("sim-server err:", line);
+          Logger.info("sim-server:", line);
           return;
         }
 
         const match = line.match(streamURLRegex);
 
         if (match) {
-          Logger.debug(`Preview server ready ${match[1]}`);
+          Logger.info(`Stream ready ${match[1]}`);
 
           this.streamURL = match[1];
           resolve(this.streamURL);
         }
-        Logger.debug("sim-server out:", line);
+        Logger.info("sim-server:", line);
       });
     });
   }

--- a/packages/vscode-extension/src/project/metro.ts
+++ b/packages/vscode-extension/src/project/metro.ts
@@ -190,7 +190,7 @@ export class Metro implements Disposable {
           reject(new Error("Metro exited but did not start server successfully."));
         });
 
-      lineReader(bundlerProcess, true).onLineRead((line) => {
+      lineReader(bundlerProcess).onLineRead((line) => {
         try {
           const event = JSON.parse(line) as MetroEvent;
           if (event.type === "bundle_transform_progressed") {


### PR DESCRIPTION
This PR modifies the behavior of lineReader which would previously only tried on reading from stderr when requested.

Since typically stderr is used to pass on important information and given almost all uses in out codebase would set stderr as `true`, this method now connects to stderr by default. 

For the use-cases where we want to be able to tell whether line comes from stderr or stdout (like with the sim-server stdout that is used as communication and control channel), the line callback gets an additional argument that indicates whether line comes from stderr.

## Test plan

Run expo-router, try clean rebuild on Android and iOS
