### PR TITLE
Improve a flow of loading devices and xcode detection

### DIFF
--- a/packages/docs/docs/troubleshooting.md
+++ b/packages/docs/docs/troubleshooting.md
@@ -84,4 +84,4 @@ If you need to install an older version of an IDE, you can do so by navigating t
 
 ### -sec-num- Configureing Alternative Xcode Versions
 
-If you are using alternative Xcode version ( e.g. xcode-beta, ["xcodes"](https://www.xcodes.app/) IDE will only work if xcode-select points to the correct directory to set it up run: `xcode-select --switch ${PathToYourXCode}/Contents/Developer`
+If you are using alternative Xcode version ( e.g. xcode-beta, ["xcodes"](https://www.xcodes.app/) ios simulators will only work if xcode-select points to the correct directory to set it up run: `xcode-select --switch ${PathToYourXCode}/Contents/Developer`

--- a/packages/vscode-extension/src/common/DeviceManager.ts
+++ b/packages/vscode-extension/src/common/DeviceManager.ts
@@ -56,7 +56,7 @@ export type DeviceManagerEventListener<K extends keyof DeviceManagerEventMap> = 
 ) => void;
 
 export interface DeviceManagerInterface {
-  listAllDevices(forceReload?: boolean): Promise<DeviceInfo[]>;
+  listAllDevices(): Promise<DeviceInfo[]>;
 
   createAndroidDevice(
     displayName: string,

--- a/packages/vscode-extension/src/common/DeviceManager.ts
+++ b/packages/vscode-extension/src/common/DeviceManager.ts
@@ -56,7 +56,7 @@ export type DeviceManagerEventListener<K extends keyof DeviceManagerEventMap> = 
 ) => void;
 
 export interface DeviceManagerInterface {
-  listAllDevices(): Promise<DeviceInfo[]>;
+  listAllDevices(forceReload?: boolean): Promise<DeviceInfo[]>;
 
   createAndroidDevice(
     displayName: string,

--- a/packages/vscode-extension/src/common/Project.ts
+++ b/packages/vscode-extension/src/common/Project.ts
@@ -115,7 +115,7 @@ export interface ProjectInterface {
   reload(type: ReloadAction): Promise<boolean>;
   restart(forceCleanBuild: boolean): Promise<void>;
   goHome(homeUrl: string): Promise<void>;
-  selectDevice(deviceInfo: DeviceInfo): Promise<void>;
+  selectDevice(deviceInfo: DeviceInfo): Promise<boolean>;
   updatePreviewZoomLevel(zoom: ZoomLevelType): Promise<void>;
 
   getDeviceSettings(): Promise<DeviceSettings>;

--- a/packages/vscode-extension/src/dependency/DependencyManager.ts
+++ b/packages/vscode-extension/src/dependency/DependencyManager.ts
@@ -166,7 +166,7 @@ export class DependencyManager implements Disposable {
 
     await command(installationCommand, {
       cwd: workspacePath,
-      quiet: true,
+      quietErrorsOnExit: true,
     });
 
     this.webview.postMessage({
@@ -425,7 +425,11 @@ export class DependencyManager implements Disposable {
 export async function checkIfCLIInstalled(cmd: string, options: Record<string, unknown> = {}) {
   try {
     // We are not checking the stderr here, because some of the CLIs put the warnings there.
-    const { stdout } = await command(cmd, { encoding: "utf8", quiet: true, ...options });
+    const { stdout } = await command(cmd, {
+      encoding: "utf8",
+      quietErrorsOnExit: true,
+      ...options,
+    });
     const result = stdout.length > 0;
     Logger.debug(`CLI: ${cmd} ${result ? "" : "not"} installed `);
     return result;

--- a/packages/vscode-extension/src/dependency/DependencyManager.ts
+++ b/packages/vscode-extension/src/dependency/DependencyManager.ts
@@ -198,12 +198,9 @@ export class DependencyManager implements Disposable {
 
   /* iOS-related */
   public async checkXcodeInstalled() {
-    const isXcodebuildInstalled = await checkIfCLIInstalled("xcodebuild -version");
-    const isXcrunInstalled = await checkIfCLIInstalled("xcrun --version");
-    const isSimctlInstalled = await checkIfCLIInstalled("xcrun simctl help");
-    const installed = isXcodebuildInstalled && isXcrunInstalled && isSimctlInstalled;
+    const installed = await checkXcodeExists();
     const errorMessage =
-      "Xcode was not found. [Install Xcode from the Mac App Store](https://apps.apple.com/us/app/xcode/id497799835?mt=12) and have Xcode Command Line Tools enabled.";
+      "Xcode was not found. If you are using alternative Xcode version you can find out more in troubleshooting section of our documentation. Otherwise, [Install Xcode from the Mac App Store](https://apps.apple.com/us/app/xcode/id497799835?mt=12) and have Xcode Command Line Tools enabled.";
     this.webview.postMessage({
       command: "isXcodeInstalled",
       data: {
@@ -428,9 +425,12 @@ export class DependencyManager implements Disposable {
 export async function checkIfCLIInstalled(cmd: string, options: Record<string, unknown> = {}) {
   try {
     // We are not checking the stderr here, because some of the CLIs put the warnings there.
-    const { stdout } = await command(cmd, { encoding: "utf8", ...options });
-    return !!stdout.length;
+    const { stdout } = await command(cmd, { encoding: "utf8", quiet: true, ...options });
+    const result = !!stdout.length;
+    Logger.debug(`CLI: ${cmd} ${result ? "" : "not"} installed `);
+    return result;
   } catch (_) {
+    Logger.debug(`CLI: ${cmd} not installed `);
     return false;
   }
 }
@@ -459,6 +459,13 @@ export function checkMinDependencyVersionInstalled(dependency: string, minVersio
     Logger.debug(message, "Module not found.");
     return "not_installed";
   }
+}
+
+export async function checkXcodeExists() {
+  const isXcodebuildInstalled = await checkIfCLIInstalled("xcodebuild -version");
+  const isXcrunInstalled = await checkIfCLIInstalled("xcrun --version");
+  const isSimctlInstalled = await checkIfCLIInstalled("xcrun simctl help");
+  return isXcodebuildInstalled && isXcrunInstalled && isSimctlInstalled;
 }
 
 export async function checkAndroidEmulatorExists() {

--- a/packages/vscode-extension/src/dependency/DependencyManager.ts
+++ b/packages/vscode-extension/src/dependency/DependencyManager.ts
@@ -426,7 +426,7 @@ export async function checkIfCLIInstalled(cmd: string, options: Record<string, u
   try {
     // We are not checking the stderr here, because some of the CLIs put the warnings there.
     const { stdout } = await command(cmd, { encoding: "utf8", quiet: true, ...options });
-    const result = !!stdout.length;
+    const result = stdout.length > 0;
     Logger.debug(`CLI: ${cmd} ${result ? "" : "not"} installed `);
     return result;
   } catch (_) {

--- a/packages/vscode-extension/src/devices/DeviceManager.ts
+++ b/packages/vscode-extension/src/devices/DeviceManager.ts
@@ -106,7 +106,12 @@ export class DeviceManager implements DeviceManagerInterface {
       return [];
     });
 
-    const shouldLoadSimulators = Platform.OS === "macos" && (await checkXcodeExists());
+    let shouldLoadSimulators = Platform.OS === "macos";
+
+    if (!(await checkXcodeExists())) {
+      shouldLoadSimulators = false;
+      Logger.debug("Couldn't list iOS simulators as XCode installation wasn't found");
+    }
 
     const simulators = shouldLoadSimulators
       ? listSimulators().catch((e) => {

--- a/packages/vscode-extension/src/devices/DeviceManager.ts
+++ b/packages/vscode-extension/src/devices/DeviceManager.ts
@@ -133,11 +133,11 @@ export class DeviceManager implements DeviceManagerInterface {
     return getAvailableIosRuntimes();
   }
 
-  public async listAllDevices(forceReload?: boolean) {
+  public async listAllDevices() {
     const devices = extensionContext.globalState.get(DEVICE_LIST_CACHE_KEY) as
       | DeviceInfo[]
       | undefined;
-    if (devices && !forceReload) {
+    if (devices) {
       // we still want to perform load here in case anything changes, just won't wait for it
       this.loadDevices();
       return devices;

--- a/packages/vscode-extension/src/devices/DeviceManager.ts
+++ b/packages/vscode-extension/src/devices/DeviceManager.ts
@@ -128,11 +128,11 @@ export class DeviceManager implements DeviceManagerInterface {
     return getAvailableIosRuntimes();
   }
 
-  public async listAllDevices(force?: boolean) {
+  public async listAllDevices(forceReload?: boolean) {
     const devices = extensionContext.globalState.get(DEVICE_LIST_CACHE_KEY) as
       | DeviceInfo[]
       | undefined;
-    if (devices && !force) {
+    if (devices && !forceReload) {
       // we still want to perform load here in case anything changes, just won't wait for it
       this.loadDevices();
       return devices;

--- a/packages/vscode-extension/src/devices/preview.ts
+++ b/packages/vscode-extension/src/devices/preview.ts
@@ -25,18 +25,8 @@ export class Preview implements Disposable {
 
     Logger.debug(`Launch preview ${simControllerBinary} ${this.args}`);
 
-    let simControllerBinaryEnv: { DYLD_FRAMEWORK_PATH: string } | undefined;
-
-    if (Platform.OS === "macos") {
-      const { stdout } = await exec("xcode-select", ["-p"]);
-      const DYLD_FRAMEWORK_PATH = path.join(stdout, "Library", "PrivateFrameworks");
-      Logger.debug(`Setting DYLD_FRAMEWORK_PATH to ${DYLD_FRAMEWORK_PATH}`);
-      simControllerBinaryEnv = { DYLD_FRAMEWORK_PATH };
-    }
-
     const subprocess = exec(simControllerBinary, this.args, {
       buffer: false,
-      env: simControllerBinaryEnv,
     });
     this.subprocess = subprocess;
 

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -203,6 +203,8 @@ export class Project
     const selectInitialDevicePromise = selectInitialDevice(devices);
 
     const listener = async (newDevices: DeviceInfo[]) => {
+      // we do this check because selectDevice which is called by selectInitialDevice sends "deviceChanged" event,
+      // when it is successful. This could cause double load of the device if lister was called before it's removal below.
       if (await selectInitialDevicePromise) {
         this.deviceManager.removeListener("devicesChanged", listener);
         return;

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -6,6 +6,7 @@ import { Logger } from "../Logger";
 import { didFingerprintChange } from "../builders/BuildManager";
 import { DeviceAlreadyUsedError, DeviceManager } from "../devices/DeviceManager";
 import { DeviceInfo } from "../common/DeviceManager";
+import { isEqual } from "lodash";
 import {
   AppPermissionType,
   DeviceSettings,
@@ -208,7 +209,7 @@ export class Project
       });
       // because devices might be outdated after xcode installation change we list them again
       const newDeviceList = await this.deviceManager.listAllDevices();
-      if (JSON.stringify(newDeviceList) !== JSON.stringify(devices)) {
+      if (!isEqual(newDeviceList, devices)) {
         selectInitialDevice(newDeviceList);
       } else {
         const listener = async (newDevices: DeviceInfo[]) => {

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -200,7 +200,7 @@ export class Project
       return false;
     };
 
-    const devices = await this.deviceManager.listAllDevices();
+    const devices = await this.deviceManager.listAllDevices(true);
     if (!selectInitialDevice(devices)) {
       const listener = (newDevices: DeviceInfo[]) => {
         if (selectInitialDevice(newDevices)) {

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -203,7 +203,7 @@ export class Project
     const selectInitialDevicePromise = selectInitialDevice(devices);
 
     const listener = async (newDevices: DeviceInfo[]) => {
-      // we do this check because listAllDevices sends "deviceChanged" event, which should be ignored if selectInitialDevice was successful
+      // we do this check because listAllDevices sends "devicesChanged" event, which should be ignored if selectInitialDevice was successful
       // but used to try again in case it was not. (e.g. when the location of Xcode was changed)
       if (await selectInitialDevicePromise) {
         this.deviceManager.removeListener("devicesChanged", listener);

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -203,8 +203,8 @@ export class Project
     const selectInitialDevicePromise = selectInitialDevice(devices);
 
     const listener = async (newDevices: DeviceInfo[]) => {
-      // we do this check because selectDevice which is called by selectInitialDevice sends "deviceChanged" event,
-      // when it is successful. This could cause double load of the device if lister was called before it's removal below.
+      // we do this check because listAllDevices sends "deviceChanged" event, which should be ignored if selectInitialDevice was successful
+      // but used to try again in case it was not. (e.g. when the location of Xcode was changed)
       if (await selectInitialDevicePromise) {
         this.deviceManager.removeListener("devicesChanged", listener);
         return;

--- a/packages/vscode-extension/src/utilities/packageManager.ts
+++ b/packages/vscode-extension/src/utilities/packageManager.ts
@@ -84,7 +84,7 @@ async function isNpmModulesInstalled(workspacePath: string): Promise<boolean> {
   try {
     const { stdout, stderr } = await command("npm ls --json", {
       cwd: workspacePath,
-      quiet: true,
+      quietErrorsOnExit: true,
     });
     const parsedJson = JSON.parse(stdout);
     return parsedJson.problems ? false : true;
@@ -102,7 +102,7 @@ async function isYarnModulesInstalled(workspacePath: string): Promise<boolean> {
     // https://docs.npmjs.com/cli/v7/commands/npm-install
     const { stdout, stderr } = await command("npm ls --json", {
       cwd: workspacePath,
-      quiet: true,
+      quietErrorsOnExit: true,
     });
     const parsedJson = JSON.parse(stdout);
 

--- a/packages/vscode-extension/src/utilities/subprocess.ts
+++ b/packages/vscode-extension/src/utilities/subprocess.ts
@@ -131,7 +131,10 @@ export function execSync(name: string, args?: string[], options?: execa.SyncOpti
   return result;
 }
 
-export function command(commandWithArgs: string, options?: execa.Options & { quiet?: boolean }) {
+export function command(
+  commandWithArgs: string,
+  options?: execa.Options & { quietErrorsOnExit?: boolean }
+) {
   const subprocess = execa.command(
     commandWithArgs,
     Platform.select({ macos: overrideEnv(options), windows: options })
@@ -147,7 +150,7 @@ export function command(commandWithArgs: string, options?: execa.Options & { qui
     }
   }
 
-  if (!options?.quiet) {
+  if (!options?.quietErrorsOnExit) {
     printErrorsOnExit(); // don't want to await here not to block the outer method
   }
 

--- a/packages/vscode-extension/src/webview/providers/ProjectProvider.tsx
+++ b/packages/vscode-extension/src/webview/providers/ProjectProvider.tsx
@@ -26,6 +26,7 @@ const ProjectContext = createContext<ProjectContextProps>({
       longitude: 19.965474,
       isDisabled: false,
     },
+    locale: "en_US",
   },
   project,
 });
@@ -46,6 +47,7 @@ export default function ProjectProvider({ children }: PropsWithChildren) {
       longitude: 19.965474,
       isDisabled: false,
     },
+    locale: "en_US",
   });
 
   useEffect(() => {

--- a/packages/vscode-extension/src/webview/views/PreviewView.tsx
+++ b/packages/vscode-extension/src/webview/views/PreviewView.tsx
@@ -20,6 +20,27 @@ import { useDiagnosticAlert } from "../hooks/useDiagnosticAlert";
 import { ZoomLevelType } from "../../common/Project";
 import { useUtils } from "../providers/UtilsProvider";
 
+type LoadingComponentProps = {
+  finishedInitialLoad: boolean;
+  devicesNotFound: boolean;
+};
+
+function LoadingComponent({ finishedInitialLoad, devicesNotFound }: LoadingComponentProps) {
+  if (!finishedInitialLoad) {
+    return (
+      <div className="missing-device-filler">
+        <VSCodeProgressRing />
+      </div>
+    );
+  }
+
+  return (
+    <div className="missing-device-filler">
+      {devicesNotFound ? <DevicesNotFoundView /> : <VSCodeProgressRing />}
+    </div>
+  );
+}
+
 function PreviewView() {
   const { projectState, project } = useProject();
   const { reportIssue } = useUtils();
@@ -93,14 +114,6 @@ function PreviewView() {
     }
   };
 
-  if (!finishedInitialLoad) {
-    return (
-      <div className="panel-view">
-        <VSCodeProgressRing />
-      </div>
-    );
-  }
-
   function onMouseDown(e: MouseEvent<HTMLDivElement>) {
     e.preventDefault();
     setIsPressing(true);
@@ -143,7 +156,7 @@ function PreviewView() {
           </IconButton>
         </SettingsDropdown>
       </div>
-      {selectedDevice ? (
+      {selectedDevice && finishedInitialLoad ? (
         <Preview
           key={selectedDevice.id}
           isInspecting={isInspecting}
@@ -154,9 +167,10 @@ function PreviewView() {
           onZoomChanged={onZoomChanged}
         />
       ) : (
-        <div className="missing-device-filler">
-          {devicesNotFound ? <DevicesNotFoundView /> : <VSCodeProgressRing />}
-        </div>
+        <LoadingComponent
+          finishedInitialLoad={finishedInitialLoad}
+          devicesNotFound={devicesNotFound}
+        />
       )}
 
       <div className="button-group-bottom">


### PR DESCRIPTION
this PR addresses a few issues with the loading devices  flow: 
- `checkIfCLIInstalled` no longer logs errors when returning false instead just logs with debug level, this change makes the logs more alined with expected results for setups without xcode
- initial device load is performed with force, as xcode installation could change between session of the ide
- initial loading screen no longer "jumps" between states 
- removed `DYLD_FRAMEWORK_PATH` as it is no longer needed
- `trySelectingInitialDevice()` creates "devicesChanged" listeners before selectingInitial device is complete, so it catches cases in which `lastDeviceId` points to the device that no longer exists (e.g. because of xcode update)