### PR TITLE
Change multitouch button for windows and fix misc minor bugs

### DIFF
--- a/packages/vscode-extension/src/Logger.ts
+++ b/packages/vscode-extension/src/Logger.ts
@@ -20,7 +20,7 @@ const logger = {
   },
 
   warn(message: string, ...args: any[]) {
-    outputChannel.error(message, ...args);
+    outputChannel.warn(message, ...args);
   },
 
   error(message: string, ...args: any[]) {

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -377,7 +377,7 @@ async function findAppRootFolder() {
       });
   }
 
-  if (appRootCandidates) {
+  if (appRootCandidates.length === 1) {
     return appRootCandidates[0];
   }
 

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -377,7 +377,7 @@ async function findAppRootFolder() {
       });
   }
 
-  if (appRootCandidates.length === 1) {
+  if (appRootCandidates.length > 0) {
     return appRootCandidates[0];
   }
 

--- a/packages/vscode-extension/src/webview/components/Preview.tsx
+++ b/packages/vscode-extension/src/webview/components/Preview.tsx
@@ -19,7 +19,7 @@ import { Resizable } from "re-resizable";
 import { useResizableProps } from "../hooks/useResizableProps";
 import ZoomControls from "./ZoomControls";
 import { throttle } from "../../utilities/throttle";
-import { useUtils } from "../providers/UtilsProvider";
+import { Platform, useUtils } from "../providers/UtilsProvider";
 import { useWorkspaceConfig } from "../providers/WorkspaceConfigProvider";
 
 declare module "react" {
@@ -446,7 +446,12 @@ function Preview({
         e.preventDefault();
         const isKeydown = e.type === "keydown";
 
-        if (e.code === "AltLeft" || e.code === "AltRight") {
+        const isMultitouchKeyPressed = Platform.select({
+          macos: e.code === "AltLeft" || e.code === "AltRight",
+          windows: e.code === "ControlLeft" || e.code === "ControlRight",
+        });
+
+        if (isMultitouchKeyPressed) {
           isKeydown && setAnchorPoint({ x: 0.5, y: 0.5 });
           setIsMultiTouching(isKeydown);
         }


### PR DESCRIPTION
This PR:
- changes the button that initiates the multitouch gesture to the `control` key on Windows
- fixes the error message display when the `diagnoseWorkspaceStructure` command cannot find the `appRoot` folder
- corrects warning messages in `Logger`