### PR TITLE
Fix new caches location in localization settings

### DIFF
--- a/packages/vscode-extension/src/devices/IosSimulatorDevice.ts
+++ b/packages/vscode-extension/src/devices/IosSimulatorDevice.ts
@@ -208,7 +208,7 @@ export class IosSimulatorDevice extends DeviceBase {
   }
 
   private async changeLocale(newLocale: Locale): Promise<boolean> {
-    const deviceSetLocation = getOrCreateDeviceSet();
+    const deviceSetLocation = getOrCreateDeviceSet(this.deviceUDID);
     const languageCode = newLocale.match(/([^_-]*)/)![1];
     await exec("/usr/libexec/PlistBuddy", [
       "-c",


### PR DESCRIPTION
This PR fixes a bug introduced by #562 witch always searched for localization settings in new caches directories for ios devices. 