### PR TITLE
Rename React Native IDE to Radon IDE in legal

### DIFF
--- a/packages/docs/src/pages/privacy-policy.mdx
+++ b/packages/docs/src/pages/privacy-policy.mdx
@@ -1,12 +1,12 @@
-# SOFTWARE MANSION REACT NATIVE IDE PRIVACY POLICY
+# SOFTWARE MANSION RADON IDE PRIVACY POLICY
 
 <br />
 
-#### Version 1.0, effective as of May 1, 2024
+#### Version 2.0, effective as of September 24, 2024
 
 <br />
 
-In this Privacy Policy, we describe the types of data, including Personal Data (collectively, “data”), that we and our associated companies collect from you when you use Software Mansion React Native IDE Website and certain Software Mansion Products and services as described in this Privacy Policy (collectively, our “services”), how we and our associated companies use and disclose that data, and your options to access or update your data.
+In this Privacy Policy, we describe the types of data, including Personal Data (collectively, “data”), that we and our associated companies collect from you when you use Software Mansion Radon IDE Website and certain Software Mansion Products and services as described in this Privacy Policy (collectively, our “services”), how we and our associated companies use and disclose that data, and your options to access or update your data.
 
 This Privacy Policy may be amended from time to time. The respective latest version of the Privacy Policy at the point of time of the purchase or registration of a Software Mansion Software Product (whichever occurs later) shall apply. The data controller is Software Mansion S.A., a joint stock company with its principal place of business at ul. Zabłocie 43b, 30-701 Kraków, Poland, entered in the register of businesses conducted by the District Court in Kraków for Kraków-Śródmieście, XI Commercial Division of the National Court Register with KRS number 0000961952, NIP 6793131302, REGON 364909814.
 
@@ -16,12 +16,12 @@ This Privacy Policy may be amended from time to time. The respective latest vers
 
 The following definitions are used throughout this Privacy Policy:
 
-**Software Mansion Software Product**. Any software product owned or created by Software Mansion and provided under Software Mansion' Subscription Agreement, including but not limited to React Native IDE. This may include, but not be limited to, code that extends the functionality of a Software Mansion Software Product (e.g., a “plugin”). Any such code is governed by its own terms and conditions and privacy policy. This also includes any Products provided free-of-charge, such as alpha and beta version and/or early access of Software Mansion Software Products.
+**Software Mansion Software Product**. Any software product owned or created by Software Mansion and provided under Software Mansion' Subscription Agreement, including but not limited to Radon IDE. This may include, but not be limited to, code that extends the functionality of a Software Mansion Software Product (e.g., a “plugin”). Any such code is governed by its own terms and conditions and privacy policy. This also includes any Products provided free-of-charge, such as alpha and beta version and/or early access of Software Mansion Software Products.
 
-**Software Mansion Downloadable Software Product**. Any Software Mansion Software Product that can be downloaded and installed on a device, offered on Software Mansion React Native IDE Website.
-Software Mansion Software as a Service. Any Software Mansion Software Product that is offered as a hosted solution, where the software is installed and maintained by Software Mansion and provided to you as a service, offered on Software Mansion React Native IDE Website.
+**Software Mansion Downloadable Software Product**. Any Software Mansion Software Product that can be downloaded and installed on a device, offered on Software Mansion Radon IDE Website.
+Software Mansion Software as a Service. Any Software Mansion Software Product that is offered as a hosted solution, where the software is installed and maintained by Software Mansion and provided to you as a service, offered on Software Mansion Radon IDE Website.
 
-**Software Mansion React Native IDE Website**. [www.ide.swmansion.com](https://ide.swmansion.com).
+**Software Mansion Radon IDE Website**. [www.ide.swmansion.com](https://ide.swmansion.com).
 
 **Software Mansion Account**. An account you create and which Software Mansion may use in communicating with you or providing Software Mansion Products to you, which contains your first name, last name, email address, username and if uploaded voluntarily, your photograph or another avatar. Your account is accessed via a username and password and can be used to manage your Personal Data.
 
@@ -68,7 +68,7 @@ Categories of data involved in data processing include:
 - comments, voluntarily provided feedback, and any data provided in survey responses,
 - data in issue reports pertaining to Software Mansion Products and services.
 
-Where appropriate, we will prompt you to give us your consent to the collection and processing of your data as described above. This may happen within Software Mansion Products, on Software Mansion React Native IDE Website, or in another environment set up by Software Mansion, always in a clear and conspicuous manner. You can manage your Personal Data and opt-outs as described in the Transparency section below.
+Where appropriate, we will prompt you to give us your consent to the collection and processing of your data as described above. This may happen within Software Mansion Products, on Software Mansion Radon IDE Website, or in another environment set up by Software Mansion, always in a clear and conspicuous manner. You can manage your Personal Data and opt-outs as described in the Transparency section below.
 
 ## Children
 
@@ -88,9 +88,9 @@ We may share your Personal Data with certain third parties which help us provide
 Your Personal Data may also be shared with other organizations or individuals if we have obtained your consent to do so.
 We may also share your Personal Data with certain third parties if we are obliged to do so under applicable legislation (especially with tax authorities or with other government bodies exercising their statutory powers) or if such sharing is necessary to achieve the purposes defined above (especially with government bodies or with parties harmed as a result of violations of applicable laws).
 To adhere to the requirements of the California Consumer Privacy Act (CCPA), we hereby notify you that Software Mansion will not a) retain, use, sell, or otherwise disclose any Personal Data for any purpose other than to provide the Products and services specified in the Subscription Agreement; or b) retain, use, sell, or disclose such Personal Data outside of the direct relationship between Customer and Software Mansion; or c) use Personal Data other than as described within (i) the Software Mansion Privacy Policy available at ide.swmansion.com/privacy-policy; (ii) the Software Mansion User Agreement available at xxx.com (iii) the Software Mansion Purchase Terms available at xxx.com or (iv) any other specific agreement you may have entered into with Software Mansion.
-YouTube API Services. We may display YouTube videos on the Software Mansion React Native IDE Website using API Client. The API Client uses YouTube API Services (link). By interacting with the video, you agree to YouTube’s Terms of Service (link) and acknowledge Google’s Privacy Policy (link). By interacting with Software Mansion React Native IDE Website, you acknowledge our Privacy Policy.
-Information we collect. The API Client collects and uses data from YouTube API Services. It also collects information from your devices you use to access Software Mansion React Native IDE Website to the extent of your tracking preferences in accordance with our Cookie Notice.
-How we use your information. We use the data collected from the API Client to display the YouTube videos through the API Client. YouTube can access information about the videos you viewed on the Software Mansion React Native IDE Website and display advertisements based on your viewing history. YouTube ad settings are available on this link. We use first and third party cookies to enhance and personalize your website experience.
+YouTube API Services. We may display YouTube videos on the Software Mansion Radon IDE Website using API Client. The API Client uses YouTube API Services (link). By interacting with the video, you agree to YouTube’s Terms of Service (link) and acknowledge Google’s Privacy Policy (link). By interacting with Software Mansion Radon IDE Website, you acknowledge our Privacy Policy.
+Information we collect. The API Client collects and uses data from YouTube API Services. It also collects information from your devices you use to access Software Mansion Radon IDE Website to the extent of your tracking preferences in accordance with our Cookie Notice.
+How we use your information. We use the data collected from the API Client to display the YouTube videos through the API Client. YouTube can access information about the videos you viewed on the Software Mansion Radon IDE Website and display advertisements based on your viewing history. YouTube ad settings are available on this link. We use first and third party cookies to enhance and personalize your website experience.
 Sharing. We may share authorized data with Google (including YouTube).
 Your rights. You can manage or revoke Google's access to your data via Google Security Settings.
 Security
@@ -110,7 +110,7 @@ Servers or services that contain Personal Data are located mainly in the US and 
 
 <br />
 
-Software Mansion React Native IDE Website may contain links to other websites provided by third parties not under Software Mansion control. When following a link and providing information to a third-party website, please be aware that Software Mansion is not responsible for the data provided to that third party. This Privacy Policy only applies to Software Mansion React Native IDE Website, so when you visit other websites, even when you click on a link posted on Software Mansion React Native IDE Website, you should read their own privacy policies.
+Software Mansion Radon IDE Website may contain links to other websites provided by third parties not under Software Mansion control. When following a link and providing information to a third-party website, please be aware that Software Mansion is not responsible for the data provided to that third party. This Privacy Policy only applies to Software Mansion Radon IDE Website, so when you visit other websites, even when you click on a link posted on Software Mansion Radon IDE Website, you should read their own privacy policies.
 
 ## Data Retention, Withdrawal of Approval, Access to Data and Your Rights
 
@@ -142,4 +142,4 @@ You may lodge a complaint related to the processing of your Personal Data with t
 
 <br />
 
-This Privacy Policy is current as of the Effective Date set forth above. We may change this Privacy Policy from time to time, so please be sure to check back periodically. We will post any changes to this Privacy Policy on Software Mansion React Native IDE Website. If we make any changes to this Privacy Policy that materially affect our practices with regard to the Personal Data we have previously collected from you, we will endeavor to provide you with an advance notice of such change by highlighting the change on Software Mansion React Native IDE Website.
+This Privacy Policy is current as of the Effective Date set forth above. We may change this Privacy Policy from time to time, so please be sure to check back periodically. We will post any changes to this Privacy Policy on Software Mansion Radon IDE Website. If we make any changes to this Privacy Policy that materially affect our practices with regard to the Personal Data we have previously collected from you, we will endeavor to provide you with an advance notice of such change by highlighting the change on Software Mansion Radon IDE Website.

--- a/packages/docs/src/pages/purchase-terms.mdx
+++ b/packages/docs/src/pages/purchase-terms.mdx
@@ -1,8 +1,8 @@
-# SOFTWARE MANSION REACT NATIVE IDE TERMS AND CONDITIONS OF PURCHASE
+# SOFTWARE MANSION RADON IDE TERMS AND CONDITIONS OF PURCHASE
 
 <br />
 
-#### Version 1, effective as of July 10, 2024
+#### Version 2.0, effective as of September 24, 2024
 
 <br />
 
@@ -81,7 +81,7 @@ If Software Mansion suspends Customer’s access to Software Mansion’ Products
 
 <br />
 
-Any refund request following the Product purchase date will be subject to prior authorization by Software Mansion, and acceptance of such request shall be at the sole discretion of Software Mansion, unless otherwise provided by applicable law. Detailed information regarding refunds can be found in React Native IDE Refund And Cancellation Terms.
+Any refund request following the Product purchase date will be subject to prior authorization by Software Mansion, and acceptance of such request shall be at the sole discretion of Software Mansion, unless otherwise provided by applicable law. Detailed information regarding refunds can be found in Radon IDE Refund And Cancellation Terms.
 
 ## EXPORT CONTROL
 

--- a/packages/docs/src/pages/refund-policy.mdx
+++ b/packages/docs/src/pages/refund-policy.mdx
@@ -1,8 +1,8 @@
-# SOFTWARE MANSION REACT NATIVE IDE REFUND AND CANCELLATION TERMS
+# SOFTWARE MANSION RADON IDE REFUND AND CANCELLATION TERMS
 
 <br />
 
-#### Version 1.0, effective as of June 1, 2024
+#### Version 2.0, effective as of September 24, 2024
 
 <br />
 
@@ -10,7 +10,7 @@
 
 <br />
 
-Software Mansion, in its sole discretion, may give refunds for some React Native IDE purchases, depending on the refund policies described below.
+Software Mansion, in its sole discretion, may give refunds for some Radon IDE purchases, depending on the refund policies described below.
 
 In general, no refunds are available for monthly or annual subscriptions.
 

--- a/packages/docs/src/pages/supporter-terms.mdx
+++ b/packages/docs/src/pages/supporter-terms.mdx
@@ -1,8 +1,8 @@
-# SOFTWARE MANSION REACT NATIVE IDE SUPPORTER SUBSCRIPTION AGREEMENT FOR INDIVIDUAL CUSTOMERS
+# SOFTWARE MANSION RADON IDE SUPPORTER SUBSCRIPTION AGREEMENT FOR INDIVIDUAL CUSTOMERS
 
 <br />
 
-#### Version 1.0, effective as of July 10, 2024
+#### Version 2.0, effective as of September 24, 2024
 
 <br />
 
@@ -29,7 +29,7 @@ XI Commercial Division of the National Court Register with KRS number 0000961952
 
 2.1. “Affiliate” means, with respect to any Party, any entity that directly, or indirectly through one or more intermediaries, controls, is controlled by, or is under common control of such Party; “control” for such purposes means the possession, direct or indirect, of the power to direct or affect the direction of the management and policies of a person or entity, whether through the ownership of voting securities, by contract, or otherwise.
 
-2.2. “Agreement” means this Supporter React Native IDE Subscription Agreement for Individual Customers.
+2.2. “Agreement” means this Supporter Radon IDE Subscription Agreement for Individual Customers.
 
 2.3. “Bug Fix Update” for a particular Product Version means a software update or release that is specifically identified by Software Mansion as a bug fix for that Product Version.
 
@@ -37,7 +37,7 @@ XI Commercial Division of the National Court Register with KRS number 0000961952
 
 2.5. “Machine” means a computing device used by Customer for running the Product.
 
-2.6. “Product” means React Native IDE created by Software Mansion, intended for mass distribution. Software Mansion does not develop Products according to Customer’s specifications, nor are Products customized through modification or personalization.
+2.6. “Product” means Radon IDE created by Software Mansion, intended for mass distribution. Software Mansion does not develop Products according to Customer’s specifications, nor are Products customized through modification or personalization.
 
 2.7. “Product Version” means a release, update, or upgrade of a particular Product that is not identified by Software Mansion as being made for the purpose of fixing software bugs.
 
@@ -51,7 +51,7 @@ XI Commercial Division of the National Court Register with KRS number 0000961952
 
 3.1 The Early Access Version Product is provided to Customer on a ‘per user’ basis, with a discount, where Customer may deploy the Early Access Version Product on multiple Machines in accordance with the Early Access Version Product documentation, provided that Customer remains the sole user of the Early Access Version Product.
 
-3.2 The Early Access Version Product license will expire on October 31, 2024 after which it will automatically renew for an additional subscription period of twelve months, if the Product will be officially launched in its full version. The fees for the new subscription period will be discounted - the Customer will receive a -50% discount for a number of months of subscription equal to the number of months of the Early Access Version Product that the Client paid for. Customer authorizes Software Mansion to charge Customer’s payment card automatically on November 1 for additional, monthly subscription period, and in the full amount of $ 19.00 and further discounted as above. For more information on how the payments are processed, please see the React Native IDE Purchase Terms available at: [ide.swmansion.com/purchase-terms](https://ide.swmansion.com/purchase-terms).
+3.2 The Early Access Version Product license will expire on October 31, 2024 after which it will automatically renew for an additional subscription period of twelve months, if the Product will be officially launched in its full version. The fees for the new subscription period will be discounted - the Customer will receive a -50% discount for a number of months of subscription equal to the number of months of the Early Access Version Product that the Client paid for. Customer authorizes Software Mansion to charge Customer’s payment card automatically on November 1 for additional, monthly subscription period, and in the full amount of $ 19.00 and further discounted as above. For more information on how the payments are processed, please see the Radon IDE Purchase Terms available at: [ide.swmansion.com/purchase-terms](https://ide.swmansion.com/purchase-terms).
 
 3.3. Unless the Subscription has expired or this Agreement is terminated in accordance with Section 12, and subject to the terms and conditions specified in this Agreement, Software Mansion grants you the non-exclusive and non-transferable right to use the Early Access Version Product covered by the Subscription as stipulated below:
 

--- a/packages/docs/src/pages/terms-of-use.mdx
+++ b/packages/docs/src/pages/terms-of-use.mdx
@@ -1,13 +1,13 @@
-# SOFTWARE MANSION REACT NATIVE IDE EARLY ACCESS EDITION TERMS
+# SOFTWARE MANSION RADON IDE EARLY ACCESS EDITION TERMS
 
 <br />
 
-#### Version 1.0, effective as of May 1, 2024
+#### Version 2.0, effective as of September 24, 2024
 
 <br />
 
 IMPORTANT! READ CAREFULLY:
-THESE TERMS APPLY TO THE SOFTWARE MANSION INTEGRATED DEVELOPMENT ENVIRONMENT TOOLS CALLED "SOFTWARE MANSION REACT NATIVE IDE" (SUCH TOOLS, "EARLY ACCESS" PRODUCTS) WHICH CONSIST OF OPEN SOURCE SOFTWARE SUBJECT TO THE LICENSE AVAILABLE HERE: **https://github.com/software-mansion/react-native-ide/blob/main/LICENSE.txt**.
+THESE TERMS APPLY TO THE SOFTWARE MANSION INTEGRATED DEVELOPMENT ENVIRONMENT TOOLS CALLED "SOFTWARE MANSION RADON IDE" (SUCH TOOLS, "EARLY ACCESS" PRODUCTS) WHICH CONSIST OF OPEN SOURCE SOFTWARE SUBJECT TO THE LICENSE AVAILABLE HERE: **https://github.com/software-mansion/react-native-ide/blob/main/LICENSE.txt**.
 
 “Software Mansion” or “we” means: Software Mansion S.A., a joint stock company with its principal place of business at ul. Zabłocie 43b, 30-701 Kraków, Poland, entered in the register of businesses conducted by the District Court in Kraków for Kraków-Śródmieście, XI Commercial Division of the National Court Register with KRS number 0000961952, NIP 6793131302, REGON 364909814.
 


### PR DESCRIPTION
This PR renames all occurences of React Native IDE to Radon IDE in legal pages in the IDE documentation.

This also affects the version of the documents presented (`1.0` -> `2.0`) and the `effective as of` date.