### PR TITLE
Fix infinite reload

### DIFF
--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -574,7 +574,6 @@ export class Project
       if (isSelected && isNewSession) {
         this.updateProjectState({ status: "buildError" });
       }
-      return false;
     }
     return true;
   }


### PR DESCRIPTION
This PR fixes a mistake introduced in  #563, the return value of `selectDevice` should indicate if device was chosen successfully, not if processes on it are successful otherwise if build fails and the selected device was set by `trySelectingInitiallDevice` we are getting stuck in infinite loop. 